### PR TITLE
Fix support for multiple interfaces on BR

### DIFF
--- a/go/border/netconf/interface.go
+++ b/go/border/netconf/interface.go
@@ -55,7 +55,8 @@ func FromTopo(intfs []common.IFIDType, infomap map[common.IFIDType]topology.IFIn
 	n.IFs = make(map[common.IFIDType]*Interface)
 	for _, ifid := range intfs {
 		ifinfo := infomap[ifid]
-		if v, ok := locIdxes[ifinfo.InternalAddrIdx]; ok && v != ifinfo.InternalAddr {
+		// XXX(matfrei) This check seems superfluous as the source for all entries is the same InternalAddrs slice.
+		if v, ok := locIdxes[ifinfo.InternalAddrIdx]; ok && !v.Equal(ifinfo.InternalAddr) {
 			return nil, common.NewBasicError("Duplicate local address index", nil,
 				"idx", ifinfo.InternalAddrIdx, "first", v, "second", ifinfo.InternalAddr)
 		}

--- a/go/lib/topology/topology.go
+++ b/go/lib/topology/topology.go
@@ -117,6 +117,7 @@ func (t *Topo) populateBR(raw *RawTopo) error {
 		for ifid, rawIntf := range rawBr.Interfaces {
 			brInfo.IFIDs = append(brInfo.IFIDs, ifid)
 			ifinfo := IFInfo{BRName: name}
+			ifinfo.InternalAddrIdx = rawIntf.InternalAddrIdx
 			intAddr := rawBr.InternalAddrs[rawIntf.InternalAddrIdx]
 			if ifinfo.InternalAddr, err = intAddr.ToTopoAddr(t.Overlay); err != nil {
 				return err

--- a/python/beacon_server/base.py
+++ b/python/beacon_server/base.py
@@ -764,8 +764,7 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
 
             # send keep-alives on all known BR interfaces
             for ifid in self.ifid2br:
-                br = self.ifid2br[ifid]
-                br_addr, br_port = br.int_addrs[0].public[0]
+                br_addr, br_port = self.get_border_addr(ifid)
                 meta = self._build_meta(host=br_addr, port=br_port)
                 self.send_meta(CtrlPayload(IFIDPayload.from_values(ifid)),
                                meta, (meta.host, meta.port))


### PR DESCRIPTION
* InternalAddressIdx not properly initialised
* Superfluous check for InternalAddresses compared pointer instead of
  values, plainly rejecting everything
* Beacon Server did not send IFID packets to correct internal address

Note: still only works properly if a separate internal address is configured
per interface, otherwise the IFID packets are not correctly forwarded.
This appears to have been fixed on the scionproto master branch (in #1587).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/netsec-scion/4)
<!-- Reviewable:end -->
