### PR TITLE
Fix unit test failures introduced in #4

### DIFF
--- a/go/lib/topology/topology_test.go
+++ b/go/lib/topology/topology_test.go
@@ -182,7 +182,8 @@ func Test_IFInfoMap(t *testing.T) {
 			IPv4:    &topoAddrInt{pubIP: net.ParseIP("10.1.0.1"), pubL4Port: 30097},
 			IPv6:    &topoAddrInt{pubIP: net.ParseIP("2001:db8:a0b:12f0::1"), pubL4Port: 30097},
 			Overlay: overlay.IPv46},
-		Overlay: overlay.UDPIPv4,
+		InternalAddrIdx: 0,
+		Overlay:         overlay.UDPIPv4,
 		Local: &TopoAddr{
 			IPv4: &topoAddrInt{
 				pubIP: net.ParseIP("192.0.2.1"), pubL4Port: 44997,
@@ -204,7 +205,8 @@ func Test_IFInfoMap(t *testing.T) {
 			IPv4:    &topoAddrInt{pubIP: net.ParseIP("10.1.0.1"), pubL4Port: 30097},
 			IPv6:    &topoAddrInt{pubIP: net.ParseIP("2001:db8:a0b:12f0::1"), pubL4Port: 30097},
 			Overlay: overlay.IPv46},
-		Overlay: overlay.IPv6,
+		InternalAddrIdx: 0,
+		Overlay:         overlay.IPv6,
 		Local: &TopoAddr{
 			IPv6: &topoAddrInt{
 				pubIP: net.ParseIP("2001:db8:a0b:12f0::1"), pubL4Port: 50000,
@@ -225,7 +227,8 @@ func Test_IFInfoMap(t *testing.T) {
 			IPv4:    &topoAddrInt{pubIP: net.ParseIP("10.1.0.2"), pubL4Port: 30097},
 			IPv6:    &topoAddrInt{pubIP: net.ParseIP("2001:db8:a0b:12f0::2"), pubL4Port: 30097},
 			Overlay: overlay.IPv46},
-		Overlay: overlay.IPv4,
+		InternalAddrIdx: 1,
+		Overlay:         overlay.IPv4,
 		Local: &TopoAddr{
 			IPv4: &topoAddrInt{
 				pubIP: net.ParseIP("192.0.2.2"), pubL4Port: 50000,


### PR DESCRIPTION
The `InternalAddrIdx` had not been set on the expected data. This made the tests fail after my change which now (correctly, I think) sets the InternalAddrIdx when loading the config.