### PR TITLE
Set PathPolicy defaults to saner values. (#1741)

### DIFF
--- a/topology/PathPolicy.yml
+++ b/topology/PathPolicy.yml
@@ -4,9 +4,9 @@ CandidatesSetSize: 20
 HistoryLimit: 20
 PropertyRanges:
   AvailableBandwidth: 0-100
-  DelayTime: 0-60
+  DelayTime: 0-14400  # <= 4hr old
   GuaranteedBandwidth: 0-100
-  HopsLength: 1-10
+  HopsLength: 1-30
   PeerLinks: 0-100
   TotalBandwidth: 0-100
 PropertyWeights:


### PR DESCRIPTION
- Accept any PCB that's <= 4 hours old (increased from 60s)
- Allow segments with 30 hops (increased from 10), as the core in the
  beginning may not be very tightly meshed.
Closes #6 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/netsec-scion/13)
<!-- Reviewable:end -->
