### PR TITLE
Increase the size of packet buffer up to 5000

### DIFF
--- a/python/scion_elem/scion_elem.py
+++ b/python/scion_elem/scion_elem.py
@@ -129,7 +129,7 @@ CONNECTED_TO_DISPATCHER = Gauge(
     "Is the element successfully registered with the dispatcher.",
     ["server_id", "isd_as"])
 
-MAX_QUEUE = 50
+MAX_QUEUE = 5000
 # Timeout for API path requests
 API_TOUT = 1
 


### PR DESCRIPTION
# Only for ScionLab

Known problem:
- All the incoming packets are stored in a single queue(packet buffer) regardless of their types
- The default size of the queue is 50
- SCIONLab used to propagate more than 50 PCBs at a time
- The surge of PCB packet transmission might cause a lot of packet drops

Driven by the problem, we decided to increase the size of queue up to 5000.
This change has been tested in real environment, and approved to be applied to the ScionLab nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/netsec-scion/16)
<!-- Reviewable:end -->
