### PR TITLE
Cherry-pick to scionlab: Fix delay_time computation to avoid division by zero

### DIFF
--- a/python/lib/path_store.py
+++ b/python/lib/path_store.py
@@ -404,8 +404,8 @@ class PathStore(object):
         """Update the delay time property of all path candidates."""
         max_delay_time = 0
         for candidate in self.candidates:
-            candidate.delay_time = (candidate.last_seen_time -
-                                    candidate.pcb.get_timestamp() + 1)
+            candidate.delay_time = max(1, (candidate.last_seen_time -
+                                           candidate.pcb.get_timestamp()))
             if candidate.delay_time > max_delay_time:
                 max_delay_time = candidate.delay_time
         for candidate in self.candidates:

--- a/python/test/lib/path_store_test.py
+++ b/python/test/lib/path_store_test.py
@@ -383,7 +383,7 @@ class TestPathStoreUpdateAllDelayTime(object):
                               for i in range(5)]
         for i in range(5):
             pcb = MagicMock(spec_set=['get_timestamp'])
-            pcb.get_timestamp.return_value = 1
+            pcb.get_timestamp.return_value = 0
             pth_str.candidates[i].pcb = pcb
             pth_str.candidates[i].last_seen_time = 2 * i + 2
         pth_str._update_all_delay_time()
@@ -391,6 +391,23 @@ class TestPathStoreUpdateAllDelayTime(object):
             pth_str.candidates[i].pcb.get_timestamp.assert_called_once_with()
             ntools.assert_almost_equal(pth_str.candidates[i].delay_time,
                                        ((2 * i + 2) / 10))
+
+    def test_pcbs_from_future(self):
+        path_policy = MagicMock(spec_set=['history_limit'])
+        path_policy.history_limit = 3
+        pth_str = PathStore(path_policy)
+        pth_str.candidates = [MagicMock(spec_set=['pcb', 'delay_time',
+                                                  'last_seen_time'])
+                              for i in range(5)]
+        for i in range(5):
+            pcb = MagicMock(spec_set=['get_timestamp'])
+            pcb.get_timestamp.return_value = 2
+            pth_str.candidates[i].pcb = pcb
+            pth_str.candidates[i].last_seen_time = i
+        pth_str._update_all_delay_time()
+        for i in range(5):
+            pth_str.candidates[i].pcb.get_timestamp.assert_called_once_with()
+            ntools.assert_true(pth_str.candidates[i].delay_time > 0)
 
 
 class TestPathStoreUpdateAllFidelity(object):


### PR DESCRIPTION
From https://github.com/scionproto/scion/pull/2076

If a PCB arrives with a timestamp from the future (which is accepted
due to the changes in #1990), it may result in a zero delay_time value.
The delay_time value is used in a division in the fidelity computation,
which will trigger an exception.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/netsec-scion/17)
<!-- Reviewable:end -->
