### PR TITLE
Workaround for many paths: set pktBufSize to 64KiB

### DIFF
--- a/go/border/rpkt/rpkt.go
+++ b/go/border/rpkt/rpkt.go
@@ -39,7 +39,7 @@ import (
 
 // pktBufSize is the maxiumum size of a packet buffer.
 // FIXME(kormat): this should be reduced as soon as we respect the actual link MTU.
-const pktBufSize = 9 * 1024
+const pktBufSize = 1 << 16
 
 // callbacks is an anonymous struct used for functions supplied by the router
 // for various processing tasks.


### PR DESCRIPTION
Workaround for messages from the (core-) path server being too large to
fit into a single message. The long-term fix will be to adopt a reliable
transport protocol for the path server messages.

Increasing pktBufSize will increase the memory usage for the border
routers. After some testing, this seemed acceptable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/netsec-scion/21)
<!-- Reviewable:end -->
