### PR TITLE
Limit number of segments returned in path request

### DIFF
--- a/go/lib/ctrl/seg/segs.go
+++ b/go/lib/ctrl/seg/segs.go
@@ -16,7 +16,6 @@ package seg
 
 import (
 	"github.com/scionproto/scion/go/lib/addr"
-	"sort"
 )
 
 // Segments is just a helper type to have additional methods on top of a slice of PathSegments.
@@ -45,23 +44,6 @@ func (segs *Segments) FilterSegsErr(keep func(*PathSegment) (bool, error)) (int,
 	}
 	*segs = filtered
 	return full - len(*segs), nil
-}
-
-// Filter to keep only the n Segments with the least number of hops
-func (segs *Segments) FilterSegsByLeastHops(n int) {
-	segs.filterOrderedSegs(n, func(i, j *PathSegment) bool {
-		return len(i.ASEntries) < len(j.ASEntries)
-	})
-}
-
-// Filter to keep only the n Segments with lowest value returned by less.
-func (segs *Segments) filterOrderedSegs(n int, less func(i, j *PathSegment) bool) {
-	if len(*segs) > n {
-		sort.Slice(*segs, func(i, j int) bool {
-			return less((*segs)[i], (*segs)[j])
-		})
-		*segs = (*segs)[0:n]
-	}
 }
 
 // FirstIAs returns the slice of FirstIAs in the given segments. Each FirstIA appears just once.

--- a/go/lib/ctrl/seg/segs.go
+++ b/go/lib/ctrl/seg/segs.go
@@ -16,6 +16,7 @@ package seg
 
 import (
 	"github.com/scionproto/scion/go/lib/addr"
+	"sort"
 )
 
 // Segments is just a helper type to have additional methods on top of a slice of PathSegments.
@@ -44,6 +45,23 @@ func (segs *Segments) FilterSegsErr(keep func(*PathSegment) (bool, error)) (int,
 	}
 	*segs = filtered
 	return full - len(*segs), nil
+}
+
+// Filter to keep only the n Segments with the least number of hops
+func (segs *Segments) FilterSegsByLeastHops(n int) {
+	segs.filterOrderedSegs(n, func(i, j *PathSegment) bool {
+		return len(i.ASEntries) < len(j.ASEntries)
+	})
+}
+
+// Filter to keep only the n Segments with lowest value returned by less.
+func (segs *Segments) filterOrderedSegs(n int, less func(i, j *PathSegment) bool) {
+	if len(*segs) > n {
+		sort.Slice(*segs, func(i, j int) bool {
+			return less((*segs)[i], (*segs)[j])
+		})
+		*segs = (*segs)[0:n]
+	}
 }
 
 // FirstIAs returns the slice of FirstIAs in the given segments. Each FirstIA appears just once.

--- a/go/path_srv/internal/handlers/segreq.go
+++ b/go/path_srv/internal/handlers/segreq.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sort"
 	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
@@ -38,7 +39,7 @@ import (
 )
 
 const (
-	maxResSegs = 5 // Maximum number of segments returned per type (up, core, down) in a reply to a segment request
+	maxResSegs = 10 // Maximum total of segments returned in a reply to a segment request
 )
 
 type segReqHandler struct {
@@ -250,4 +251,189 @@ func segsToMap(segs []*seg.PathSegment,
 		res[key(s)] = struct{}{}
 	}
 	return res
+}
+
+// Combination of up, core and down segments (aka a Path).
+type connectedSegs struct {
+	Up, Core, Down *seg.PathSegment
+}
+
+func (p *connectedSegs) numHops() int {
+
+	n := 0
+	if p.Up != nil {
+		n += len(p.Up.ASEntries)
+	}
+	if p.Core != nil {
+		n += len(p.Core.ASEntries)
+	}
+	if p.Down != nil {
+		n += len(p.Down.ASEntries)
+	}
+	return n
+}
+
+// Filter upSegs, coreSegs and downSegs to include at most maxNumSegments segments. Ensures that the remaining segments can be connected to allow forming paths between srcIA and dstIA.
+func selectConnectedSegs(maxNumSegments int, upSegs, coreSegs, downSegs *seg.Segments, srcIA, dstIA addr.IA) {
+
+	plen := func(s *seg.Segments) int {
+		if s != nil {
+			return len(*s)
+		}
+		return 0
+	}
+
+	if plen(upSegs)+plen(coreSegs)+plen(downSegs) < maxNumSegments {
+		return
+	}
+
+	paths := allConnectedSegs(upSegs, coreSegs, downSegs, srcIA, dstIA)
+	// Sort by least number of hops for path
+	sort.Slice(paths, func(i, j int) bool {
+		return paths[i].numHops() < paths[j].numHops()
+	})
+
+	selSegs := make(map[*seg.PathSegment]struct{})
+	for _, path := range paths {
+		if len(selSegs) > maxNumSegments-3 {
+			break
+		}
+
+		if path.Up != nil {
+			selSegs[path.Up] = struct{}{}
+		}
+		if path.Core != nil {
+			selSegs[path.Core] = struct{}{}
+		}
+		if path.Down != nil {
+			selSegs[path.Down] = struct{}{}
+		}
+	}
+
+	selSegFunc := func(s *seg.PathSegment) bool {
+		_, selected := selSegs[s]
+		return selected
+	}
+	if upSegs != nil {
+		upSegs.FilterSegs(selSegFunc)
+	}
+	if coreSegs != nil {
+		coreSegs.FilterSegs(selSegFunc)
+	}
+	if downSegs != nil {
+		downSegs.FilterSegs(selSegFunc)
+	}
+}
+
+func matchReqIA(addr, req addr.IA) bool {
+	return addr.Eq(req) || (addr.I == req.I && req.A == 0)
+}
+
+// Helper for selectConnectedSegs.
+// Create all connected combinations of up-core-down segments, starting at srcIA, ending at dstIA.
+// Both upSegs and downSegs may be nil. Assumes that:
+// - if upSegs is present, upSegs start (==LastIA()) is srcIA,
+// - if downSegs is present, downSegs end (==LastIA()) in dstIA
+// - if upSegs are present, srcIA is not core
+// - if downSegs are present, dstIA is not core
+func allConnectedSegs(upSegs, coreSegs, downSegs *seg.Segments, srcIA, dstIA addr.IA) []connectedSegs {
+
+	log.Trace("allConnectedSegs:")
+	paths := make([]connectedSegs, 0)
+
+	// Core direct
+	for _, coreSeg := range *coreSegs {
+		if matchReqIA(coreSeg.LastIA(), srcIA) && matchReqIA(coreSeg.FirstIA(), dstIA) {
+			paths = append(paths, connectedSegs{
+				Up:   nil,
+				Core: coreSeg,
+				Down: nil,
+			})
+		}
+	}
+	if upSegs != nil && downSegs != nil {
+		// Up-Down direct
+		for _, upSeg := range *upSegs {
+			for _, downSeg := range *downSegs {
+				if upSeg.FirstIA().Eq(downSeg.FirstIA()) {
+					paths = append(paths, connectedSegs{
+						Up:   upSeg,
+						Core: nil,
+						Down: downSeg,
+					})
+				}
+			}
+		}
+		// Up-Core-Down
+		for _, upSeg := range *upSegs {
+			for _, coreSeg := range *coreSegs {
+				if !upSeg.FirstIA().Eq(coreSeg.LastIA()) {
+					continue
+				}
+				for _, downSeg := range *downSegs {
+					if !coreSeg.FirstIA().Eq(downSeg.FirstIA()) {
+						continue
+					}
+					paths = append(paths, connectedSegs{
+						Up:   upSeg,
+						Core: coreSeg,
+						Down: downSeg,
+					})
+				}
+			}
+		}
+	} else if upSegs == nil {
+		// Down from src
+		for _, downSeg := range *downSegs {
+			log.Trace("down from src", "downFirst", downSeg.FirstIA(), "downLast", downSeg.LastIA(), "src", srcIA, "dst", dstIA)
+			if matchReqIA(downSeg.FirstIA(), srcIA) {
+				paths = append(paths, connectedSegs{
+					Up:   nil,
+					Core: nil,
+					Down: downSeg,
+				})
+			}
+		}
+		// Core-Down
+		for _, coreSeg := range *coreSegs {
+			for _, downSeg := range *downSegs {
+				log.Trace("core-down", "coreFirst", coreSeg.FirstIA(), "coreLast", coreSeg.LastIA(), "downFirst", downSeg.FirstIA(), "downLast", downSeg.LastIA(), "src", srcIA, "dst", dstIA)
+				if !coreSeg.LastIA().Eq(downSeg.FirstIA()) {
+					continue
+				}
+				paths = append(paths, connectedSegs{
+					Up:   nil,
+					Core: coreSeg,
+					Down: downSeg,
+				})
+			}
+		}
+	} else if downSegs == nil {
+		// Up to dst
+		for _, upSeg := range *upSegs {
+			log.Trace("up to dst", "upFirst", upSeg.FirstIA(), "upLast", upSeg.LastIA(), "src", srcIA, "dst", dstIA)
+			if matchReqIA(upSeg.FirstIA(), dstIA) {
+				paths = append(paths, connectedSegs{
+					Up:   upSeg,
+					Core: nil,
+					Down: nil,
+				})
+			}
+		}
+		// Up-Core
+		for _, upSeg := range *upSegs {
+			for _, coreSeg := range *coreSegs {
+				log.Trace("up-core:", "upFirst", upSeg.FirstIA(), "upLast", upSeg.LastIA(), "coreFirst", coreSeg.FirstIA(), "coreLast", coreSeg.LastIA(), "src", srcIA, "dst", dstIA)
+				if !upSeg.FirstIA().Eq(coreSeg.LastIA()) {
+					continue
+				}
+				paths = append(paths, connectedSegs{
+					Up:   upSeg,
+					Core: coreSeg,
+					Down: nil,
+				})
+			}
+		}
+	}
+	return paths
 }

--- a/go/path_srv/internal/handlers/segreq.go
+++ b/go/path_srv/internal/handlers/segreq.go
@@ -37,6 +37,10 @@ import (
 	"github.com/scionproto/scion/go/proto"
 )
 
+const (
+	maxResSegs = 5 // Maximum number of segments returned per type (up, core, down) in a reply to a segment request
+)
+
 type segReqHandler struct {
 	*baseHandler
 	localIA     addr.IA

--- a/go/path_srv/internal/handlers/segreqnoncore.go
+++ b/go/path_srv/internal/handlers/segreqnoncore.go
@@ -134,23 +134,11 @@ func (h *segReqNonCoreHandler) handleCoreDst(ctx context.Context, segReq *path_m
 			}
 		}
 	}
-	lenCoreSegsBefore := len(coreSegs)
-	coreSegs.FilterSegsByLeastHops(maxResSegs)
 
-	// All firstIAs of upSegs that are connected, used for filtering later.
-	connFirstIAs := make(map[addr.IA]struct{})
-	connFirstIAs[dst] = struct{}{}
-	for _, coreSeg := range coreSegs {
-		connFirstIAs[coreSeg.FirstIA()] = struct{}{}
-	}
-	// Make sure we only return connected segments.
-	upSegs.FilterSegs(func(s *seg.PathSegment) bool {
-		_, connected := connFirstIAs[s.FirstIA()]
-		return connected
-	})
-	lenUpSegsBefore := len(upSegs)
-	upSegs.FilterSegsByLeastHops(maxResSegs)
-	logger.Debug("[segReqHandler] found", "up", len(upSegs), "/", lenUpSegsBefore, "core", len(coreSegs), "/", lenCoreSegsBefore)
+	logger.Debug("[segReqHandler] found segs", "up", len(upSegs), "core", len(coreSegs))
+	selectConnectedSegs(maxResSegs, &upSegs, &coreSegs, nil, h.localIA, dst)
+
+	logger.Debug("[segReqHandler] returning segs", "up", len(upSegs), "core", len(coreSegs))
 	h.sendReply(ctx, msger, upSegs, coreSegs, nil, segReq)
 }
 
@@ -186,6 +174,9 @@ func (h *segReqNonCoreHandler) handleNonCoreDst(ctx context.Context, segReq *pat
 		// TODO(lukedirtwalker): we shouldn't just query all cores, this could be a lot of overhead.
 		// Add a limit of cores we query.
 		for _, src := range upSegs.FirstIAs() {
+			if src.Eq(dst) {
+				continue
+			}
 			cs, err := h.fetchCoreSegs(ctx, msger, src, dst, segReq.Flags.CacheOnly)
 			if err != nil {
 				logger.Error("Failed to find core segs", "src", src, "dst", dst, "err", err)
@@ -194,40 +185,11 @@ func (h *segReqNonCoreHandler) handleNonCoreDst(ctx context.Context, segReq *pat
 			coreSegs = append(coreSegs, cs...)
 		}
 	}
-	coreSegs.FilterSegsByLeastHops(maxResSegs)
-
-	// All firstIAs of up-/down-Segs that are connected, used for filtering later.
-	connUpFirstIAs := make(map[addr.IA]struct{})
-	connDownFirstIAs := make(map[addr.IA]struct{})
-	for _, dst := range downSegs.FirstIAs() {
-		for _, src := range upSegs.FirstIAs() {
-			if src.Eq(dst) {
-				connUpFirstIAs[src] = struct{}{}
-				connDownFirstIAs[dst] = struct{}{}
-			}
-		}
-	}
-	for _, coreSeg := range coreSegs {
-		connUpFirstIAs[coreSeg.FirstIA()] = struct{}{}
-		connDownFirstIAs[coreSeg.LastIA()] = struct{}{}
-	}
-
-	lenUpSegsBefore := len(upSegs)
-	// Make sure we only return connected segments.
-	// No need to filter cores, since we only query for connected ones.
-	upSegs.FilterSegs(func(s *seg.PathSegment) bool {
-		_, connected := connUpFirstIAs[s.FirstIA()]
-		return connected
-	})
-	upSegs.FilterSegsByLeastHops(maxResSegs)
-	lenDownSegsBefore := len(downSegs)
-	downSegs.FilterSegs(func(s *seg.PathSegment) bool {
-		_, connected := connDownFirstIAs[s.FirstIA()]
-		return connected
-	})
-	downSegs.FilterSegsByLeastHops(maxResSegs)
 	logger.Debug("[segReqHandler:handleNonCoreDst] found segs",
-		"up", len(upSegs), "upBefore", lenUpSegsBefore, "core", len(coreSegs), "down", len(downSegs), "downBefore", lenDownSegsBefore)
+		"up", len(upSegs), "core", len(coreSegs), "down", len(downSegs))
+	selectConnectedSegs(maxResSegs, &upSegs, &coreSegs, &downSegs, h.localIA, dstIA)
+	logger.Debug("[segReqHandler:handleNonCoreDst] returning segs",
+		"up", len(upSegs), "core", len(coreSegs), "down", len(downSegs))
 	h.sendReply(ctx, msger, upSegs, coreSegs, downSegs, segReq)
 }
 


### PR DESCRIPTION
Fix for https://github.com/scionproto/scion/issues/2413

Note on implementation: a first attempt (~first commit in this PR) was to filter the lists of up, down and core segments individually -- as far as I understand this is analogous to how this happens in the python PS. However, the filtering to only return segments that can be connected to paths became rather unwieldy. Also, when selecting the segments, only the number of hops in an individual segment could be considered. The current implementation considers the number of hops in a *path* (consisting of a combination of up/core/down segments) which seems to make more sense.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/netsec-scion/22)
<!-- Reviewable:end -->
