### PR TITLE
Limit number of segments returned

### DIFF
--- a/go/lib/infra/modules/combinator/graph.go
+++ b/go/lib/infra/modules/combinator/graph.go
@@ -354,7 +354,7 @@ func (solution *PathSolution) GetFwdPathMetadata() *Path {
 	return path
 }
 
-// Get the segments constituting this path
+// Segments returns the segments in this path
 func (solution *PathSolution) Segments() []*InputSegment {
 	segs := make([]*InputSegment, 0, len(solution.edges))
 	for _, e := range solution.edges {

--- a/go/lib/infra/modules/combinator/graph.go
+++ b/go/lib/infra/modules/combinator/graph.go
@@ -354,6 +354,15 @@ func (solution *PathSolution) GetFwdPathMetadata() *Path {
 	return path
 }
 
+// Get the segments constituting this path
+func (solution *PathSolution) Segments() []*InputSegment {
+	segs := make([]*InputSegment, 0, len(solution.edges))
+	for _, e := range solution.edges {
+		segs = append(segs, e.segment)
+	}
+	return segs
+}
+
 // PathSolutionList is a sort.Interface implementation for a slice of solutions.
 type PathSolutionList []*PathSolution
 

--- a/go/path_srv/internal/handlers/segreq.go
+++ b/go/path_srv/internal/handlers/segreq.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/assert"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/seg"
@@ -40,9 +41,9 @@ import (
 )
 
 var (
-	// Maximum total of segments returned in a reply to a segment
-	// request. A value <= 0 is interpreted as unlimited, i.e. all segments will
-	// be returned.
+	// MaxResSegs is the maximum total of segments returned in a reply to a
+	// segment request. A value <= 0 is interpreted as unlimited, i.e. all
+	// segments will be returned.
 	MaxResSegs = 10
 )
 
@@ -245,8 +246,9 @@ func (h *segReqHandler) shouldRefetchSegsForDst(ctx context.Context, dst addr.IA
 	return now.After(*nq), nil
 }
 
-// Filter upSegs, coreSegs and downSegs to include at most MaxResSegs segments. Ensures that the
-// remaining segments can be connected to allow forming paths between src and dst.
+// selectConnectedSegs filters upSegs, coreSegs and downSegs to include at most
+// MaxResSegs segments. Ensures that the remaining segments can be connected to
+// allow forming paths between src and dst.
 func selectConnectedSegs(upSegs, coreSegs, downSegs *seg.Segments,
 	src, dst addr.IA) {
 
@@ -277,15 +279,17 @@ func selectConnectedSegs(upSegs, coreSegs, downSegs *seg.Segments,
 func selectConnectedSegsImpl(upSegs, coreSegs, downSegs seg.Segments,
 	src, dst addr.IA) (seg.Segments, seg.Segments, seg.Segments) {
 
-	srcs := expandWildcard(upSegs, coreSegs, downSegs, src)
+	if assert.On {
+		assert.Must(!src.IsWildcard(), "Wildcard not expected for src-IA")
+		assert.Must(dst.I != 0, "Wildcard not expected for dst-ISD")
+	}
+
 	dsts := expandWildcard(upSegs, coreSegs, downSegs, dst)
 	graph := combinator.NewDMG(upSegs, coreSegs, downSegs)
 	var paths combinator.PathSolutionList
-	for _, s := range srcs {
-		for _, d := range dsts {
-			sdpaths := graph.GetPaths(combinator.VertexFromIA(s), combinator.VertexFromIA(d))
-			paths = append(paths, sdpaths...)
-		}
+	for _, d := range dsts {
+		sdpaths := graph.GetPaths(combinator.VertexFromIA(src), combinator.VertexFromIA(d))
+		paths = append(paths, sdpaths...)
 	}
 	sort.Sort(paths)
 
@@ -322,7 +326,7 @@ func selectConnectedSegsImpl(upSegs, coreSegs, downSegs seg.Segments,
 	return upSegs, coreSegs, downSegs
 }
 
-// Return all core AS matching wildcard ia.
+// expandWildcard returns all core AS matching wildcard ia.
 func expandWildcard(upSegs, coreSegs, downSegs seg.Segments, ia addr.IA) []addr.IA {
 	if !ia.IsWildcard() {
 		return []addr.IA{ia}
@@ -335,11 +339,11 @@ func expandWildcard(upSegs, coreSegs, downSegs seg.Segments, ia addr.IA) []addr.
 	return getMatchingIAs(ias, ia)
 }
 
-// Get the IAs in ias matching the wildcard IA pat
+// getMatchingIAs returns the IAs in ias matching the IA pat with a wildcard AS.
 func getMatchingIAs(ias []addr.IA, pat addr.IA) []addr.IA {
-	ret := []addr.IA{}
+	var ret []addr.IA
 	for _, ia := range ias {
-		if (pat.I == 0 || ia.I == pat.I) && (pat.A == 0 || ia.A == pat.A) {
+		if ia.I == pat.I && (pat.A == 0 || ia.A == pat.A) {
 			ret = append(ret, ia)
 		}
 	}

--- a/go/path_srv/internal/handlers/segreq.go
+++ b/go/path_srv/internal/handlers/segreq.go
@@ -252,40 +252,13 @@ func (h *segReqHandler) shouldRefetchSegsForDst(ctx context.Context, dst addr.IA
 func selectConnectedSegs(upSegs, coreSegs, downSegs *seg.Segments,
 	src, dst addr.IA) {
 
-	var tmpUp, tmpCore, tmpDown seg.Segments
-	if upSegs != nil {
-		tmpUp = *upSegs
-	}
-	if coreSegs != nil {
-		tmpCore = *coreSegs
-	}
-	if downSegs != nil {
-		tmpDown = *downSegs
-	}
-
-	tmpUp, tmpCore, tmpDown = selectConnectedSegsImpl(tmpUp, tmpCore, tmpDown, src, dst)
-
-	if upSegs != nil {
-		*upSegs = tmpUp
-	}
-	if coreSegs != nil {
-		*coreSegs = tmpCore
-	}
-	if downSegs != nil {
-		*downSegs = tmpDown
-	}
-}
-
-func selectConnectedSegsImpl(upSegs, coreSegs, downSegs seg.Segments,
-	src, dst addr.IA) (seg.Segments, seg.Segments, seg.Segments) {
-
 	if assert.On {
 		assert.Must(!src.IsWildcard(), "Wildcard not expected for src-IA")
 		assert.Must(dst.I != 0, "Wildcard not expected for dst-ISD")
 	}
 
-	dsts := expandWildcard(upSegs, coreSegs, downSegs, dst)
-	graph := combinator.NewDMG(upSegs, coreSegs, downSegs)
+	dsts := expandWildcard(*upSegs, *coreSegs, *downSegs, dst)
+	graph := combinator.NewDMG(*upSegs, *coreSegs, *downSegs)
 	var paths combinator.PathSolutionList
 	for _, d := range dsts {
 		sdpaths := graph.GetPaths(combinator.VertexFromIA(src), combinator.VertexFromIA(d))
@@ -323,7 +296,6 @@ func selectConnectedSegsImpl(upSegs, coreSegs, downSegs seg.Segments,
 	upSegs.FilterSegs(selSegFunc)
 	coreSegs.FilterSegs(selSegFunc)
 	downSegs.FilterSegs(selSegFunc)
-	return upSegs, coreSegs, downSegs
 }
 
 // expandWildcard returns all core AS matching wildcard ia.

--- a/go/path_srv/internal/handlers/segreq.go
+++ b/go/path_srv/internal/handlers/segreq.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sort"
 	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
@@ -27,6 +28,7 @@ import (
 	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/infra/dedupe"
 	"github.com/scionproto/scion/go/lib/infra/messenger"
+	"github.com/scionproto/scion/go/lib/infra/modules/combinator"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/pathdb/query"
 	"github.com/scionproto/scion/go/lib/revcache"
@@ -35,6 +37,13 @@ import (
 	"github.com/scionproto/scion/go/lib/snet"
 	"github.com/scionproto/scion/go/path_srv/internal/segutil"
 	"github.com/scionproto/scion/go/proto"
+)
+
+var (
+	// Maximum total of segments returned in a reply to a segment
+	// request. A value <= 0 is interpreted as unlimited, i.e. all segments will
+	// be returned.
+	MaxResSegs = 10
 )
 
 type segReqHandler struct {
@@ -236,14 +245,103 @@ func (h *segReqHandler) shouldRefetchSegsForDst(ctx context.Context, dst addr.IA
 	return now.After(*nq), nil
 }
 
-// segsToMap converts the segs slice to a map of IAs to segments.
-// The IA (key) is selected using the key function.
-func segsToMap(segs []*seg.PathSegment,
-	key func(*seg.PathSegment) addr.IA) map[addr.IA]struct{} {
+// Filter upSegs, coreSegs and downSegs to include at most MaxResSegs segments. Ensures that the
+// remaining segments can be connected to allow forming paths between src and dst.
+func selectConnectedSegs(upSegs, coreSegs, downSegs *seg.Segments,
+	src, dst addr.IA) {
 
-	res := make(map[addr.IA]struct{})
-	for _, s := range segs {
-		res[key(s)] = struct{}{}
+	var tmpUp, tmpCore, tmpDown seg.Segments
+	if upSegs != nil {
+		tmpUp = *upSegs
 	}
-	return res
+	if coreSegs != nil {
+		tmpCore = *coreSegs
+	}
+	if downSegs != nil {
+		tmpDown = *downSegs
+	}
+
+	tmpUp, tmpCore, tmpDown = selectConnectedSegsImpl(tmpUp, tmpCore, tmpDown, src, dst)
+
+	if upSegs != nil {
+		*upSegs = tmpUp
+	}
+	if coreSegs != nil {
+		*coreSegs = tmpCore
+	}
+	if downSegs != nil {
+		*downSegs = tmpDown
+	}
+}
+
+func selectConnectedSegsImpl(upSegs, coreSegs, downSegs seg.Segments,
+	src, dst addr.IA) (seg.Segments, seg.Segments, seg.Segments) {
+
+	srcs := expandWildcard(upSegs, coreSegs, downSegs, src)
+	dsts := expandWildcard(upSegs, coreSegs, downSegs, dst)
+	graph := combinator.NewDMG(upSegs, coreSegs, downSegs)
+	var paths combinator.PathSolutionList
+	for _, s := range srcs {
+		for _, d := range dsts {
+			sdpaths := graph.GetPaths(combinator.VertexFromIA(s), combinator.VertexFromIA(d))
+			paths = append(paths, sdpaths...)
+		}
+	}
+	sort.Sort(paths)
+
+	selSegs := make(map[*seg.PathSegment]struct{})
+	for _, p := range paths {
+		if MaxResSegs > 0 && len(selSegs) >= MaxResSegs {
+			break
+		}
+		segs := p.Segments()
+
+		// check if the this path could fit.
+		numNew := 0
+		for _, seg := range segs {
+			if _, ok := selSegs[seg.PathSegment]; !ok {
+				numNew++
+			}
+		}
+		if MaxResSegs > 0 && len(selSegs)+numNew > MaxResSegs {
+			continue
+		}
+		// mark segs as used
+		for _, seg := range segs {
+			selSegs[seg.PathSegment] = struct{}{}
+		}
+	}
+
+	selSegFunc := func(s *seg.PathSegment) bool {
+		_, selected := selSegs[s]
+		return selected
+	}
+	upSegs.FilterSegs(selSegFunc)
+	coreSegs.FilterSegs(selSegFunc)
+	downSegs.FilterSegs(selSegFunc)
+	return upSegs, coreSegs, downSegs
+}
+
+// Return all core AS matching wildcard ia.
+func expandWildcard(upSegs, coreSegs, downSegs seg.Segments, ia addr.IA) []addr.IA {
+	if !ia.IsWildcard() {
+		return []addr.IA{ia}
+	}
+	// Gather core ASes, i.e. the candidates for the wildcard
+	ias := upSegs.FirstIAs()
+	ias = append(ias, coreSegs.FirstIAs()...)
+	ias = append(ias, coreSegs.LastIAs()...)
+	ias = append(ias, downSegs.FirstIAs()...)
+	return getMatchingIAs(ias, ia)
+}
+
+// Get the IAs in ias matching the wildcard IA pat
+func getMatchingIAs(ias []addr.IA, pat addr.IA) []addr.IA {
+	ret := []addr.IA{}
+	for _, ia := range ias {
+		if (pat.I == 0 || ia.I == pat.I) && (pat.A == 0 || ia.A == pat.A) {
+			ret = append(ret, ia)
+		}
+	}
+	return ret
 }

--- a/go/path_srv/internal/handlers/segreq.go
+++ b/go/path_srv/internal/handlers/segreq.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
-	"github.com/scionproto/scion/go/lib/assert"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/seg"
@@ -252,17 +251,15 @@ func (h *segReqHandler) shouldRefetchSegsForDst(ctx context.Context, dst addr.IA
 func selectConnectedSegs(upSegs, coreSegs, downSegs *seg.Segments,
 	src, dst addr.IA) {
 
-	if assert.On {
-		assert.Must(!src.IsWildcard(), "Wildcard not expected for src-IA")
-		assert.Must(dst.I != 0, "Wildcard not expected for dst-ISD")
-	}
-
+	srcs := expandWildcard(*upSegs, *coreSegs, *downSegs, src)
 	dsts := expandWildcard(*upSegs, *coreSegs, *downSegs, dst)
 	graph := combinator.NewDMG(*upSegs, *coreSegs, *downSegs)
 	var paths combinator.PathSolutionList
-	for _, d := range dsts {
-		sdpaths := graph.GetPaths(combinator.VertexFromIA(src), combinator.VertexFromIA(d))
-		paths = append(paths, sdpaths...)
+	for _, s := range srcs {
+		for _, d := range dsts {
+			sdpaths := graph.GetPaths(combinator.VertexFromIA(s), combinator.VertexFromIA(d))
+			paths = append(paths, sdpaths...)
+		}
 	}
 	sort.Sort(paths)
 
@@ -311,11 +308,11 @@ func expandWildcard(upSegs, coreSegs, downSegs seg.Segments, ia addr.IA) []addr.
 	return getMatchingIAs(ias, ia)
 }
 
-// getMatchingIAs returns the IAs in ias matching the IA pat with a wildcard AS.
+// getMatchingIAs returns the IAs in ias matching the wildcard IA pat
 func getMatchingIAs(ias []addr.IA, pat addr.IA) []addr.IA {
 	var ret []addr.IA
 	for _, ia := range ias {
-		if ia.I == pat.I && (pat.A == 0 || ia.A == pat.A) {
+		if (pat.I == 0 || ia.I == pat.I) && (pat.A == 0 || ia.A == pat.A) {
 			ret = append(ret, ia)
 		}
 	}

--- a/go/path_srv/internal/handlers/segreqcore.go
+++ b/go/path_srv/internal/handlers/segreqcore.go
@@ -139,14 +139,13 @@ func (h *segReqCoreHandler) handleCoreDst(ctx context.Context,
 	msger infra.Messenger, segReq *path_mgmt.SegReq) {
 
 	logger := log.FromCtx(ctx)
-	var coreSegs seg.Segments
 	coreSegs, err := h.fetchCoreSegsFromDB(ctx, []addr.IA{segReq.DstIA()}, !segReq.Flags.CacheOnly)
 	if err != nil {
 		logger.Error("Failed to find core segs", "err", err)
 		return
 	}
 	logger.Debug("[segReqHandler:handleCoreDst] found segs", "core", len(coreSegs))
-	selectConnectedSegs(nil, &coreSegs, nil, segReq.SrcIA(), segReq.DstIA())
+	selectConnectedSegs(nil, (*seg.Segments)(&coreSegs), nil, segReq.SrcIA(), segReq.DstIA())
 	logger.Debug("[segReqHandler:handleCoreDst] returning segs", "core", len(coreSegs))
 	h.sendReply(ctx, msger, nil, coreSegs, nil, segReq)
 }

--- a/go/path_srv/internal/handlers/segreqcore.go
+++ b/go/path_srv/internal/handlers/segreqcore.go
@@ -130,7 +130,8 @@ func (h *segReqCoreHandler) handleReq(ctx context.Context,
 		}
 	}
 	logger.Debug("[segReqCoreHandler] found segs", "core", len(coreSegs), "down", len(downSegs))
-	selectConnectedSegs(nil, &coreSegs, &downSegs, segReq.SrcIA(), segReq.DstIA())
+	selectConnectedSegs(&seg.Segments{}, &coreSegs, &downSegs,
+		segReq.SrcIA(), segReq.DstIA())
 	logger.Debug("[segReqCoreHandler] returning segs", "core", len(coreSegs), "down", len(downSegs))
 	h.sendReply(ctx, msger, nil, coreSegs, downSegs, segReq)
 }
@@ -145,7 +146,8 @@ func (h *segReqCoreHandler) handleCoreDst(ctx context.Context,
 		return
 	}
 	logger.Debug("[segReqHandler:handleCoreDst] found segs", "core", len(coreSegs))
-	selectConnectedSegs(nil, (*seg.Segments)(&coreSegs), nil, segReq.SrcIA(), segReq.DstIA())
+	selectConnectedSegs(&seg.Segments{}, (*seg.Segments)(&coreSegs), &seg.Segments{},
+		segReq.SrcIA(), segReq.DstIA())
 	logger.Debug("[segReqHandler:handleCoreDst] returning segs", "core", len(coreSegs))
 	h.sendReply(ctx, msger, nil, coreSegs, nil, segReq)
 }

--- a/go/path_srv/internal/handlers/segreqcore.go
+++ b/go/path_srv/internal/handlers/segreqcore.go
@@ -107,7 +107,7 @@ func (h *segReqCoreHandler) handleReq(ctx context.Context,
 		h.sendEmptySegReply(ctx, segReq, msger)
 		return
 	}
-	var coreSegs []*seg.PathSegment
+	var coreSegs seg.Segments
 	// if request came from same AS also return core segs, to start of down segs.
 	if segReq.SrcIA().Eq(h.localIA) {
 		ias := downSegs.FirstIAs()
@@ -128,17 +128,10 @@ func (h *segReqCoreHandler) handleReq(ctx context.Context,
 				return
 			}
 		}
-		// Remove disconnected down segs.
-		// Core segments can only end at the given down segs, thus do not need to be filtered.
-		coreDowns := segsToMap(coreSegs, (*seg.PathSegment).FirstIA)
-		// localIA is always a valid start point
-		coreDowns[h.localIA] = struct{}{}
-		downSegs.FilterSegs(func(s *seg.PathSegment) bool {
-			_, coreExists := coreDowns[s.FirstIA()]
-			return coreExists
-		})
 	}
 	logger.Debug("[segReqCoreHandler] found segs", "core", len(coreSegs), "down", len(downSegs))
+	selectConnectedSegs(nil, &coreSegs, &downSegs, segReq.SrcIA(), segReq.DstIA())
+	logger.Debug("[segReqCoreHandler] returning segs", "core", len(coreSegs), "down", len(downSegs))
 	h.sendReply(ctx, msger, nil, coreSegs, downSegs, segReq)
 }
 
@@ -146,12 +139,15 @@ func (h *segReqCoreHandler) handleCoreDst(ctx context.Context,
 	msger infra.Messenger, segReq *path_mgmt.SegReq) {
 
 	logger := log.FromCtx(ctx)
+	var coreSegs seg.Segments
 	coreSegs, err := h.fetchCoreSegsFromDB(ctx, []addr.IA{segReq.DstIA()}, !segReq.Flags.CacheOnly)
 	if err != nil {
 		logger.Error("Failed to find core segs", "err", err)
 		return
 	}
 	logger.Debug("[segReqHandler:handleCoreDst] found segs", "core", len(coreSegs))
+	selectConnectedSegs(nil, &coreSegs, nil, segReq.SrcIA(), segReq.DstIA())
+	logger.Debug("[segReqHandler:handleCoreDst] returning segs", "core", len(coreSegs))
 	h.sendReply(ctx, msger, nil, coreSegs, nil, segReq)
 }
 

--- a/go/path_srv/internal/handlers/segreqnoncore.go
+++ b/go/path_srv/internal/handlers/segreqnoncore.go
@@ -136,7 +136,7 @@ func (h *segReqNonCoreHandler) handleCoreDst(ctx context.Context, segReq *path_m
 	}
 
 	logger.Debug("[segReqHandler] found segs", "up", len(upSegs), "core", len(coreSegs))
-	selectConnectedSegs(&upSegs, &coreSegs, nil, h.localIA, dst)
+	selectConnectedSegs(&upSegs, &coreSegs, &seg.Segments{}, h.localIA, dst)
 	logger.Debug("[segReqHandler] returning segs", "up", len(upSegs), "core", len(coreSegs))
 	h.sendReply(ctx, msger, upSegs, coreSegs, nil, segReq)
 }

--- a/go/path_srv/internal/handlers/segreqnoncore.go
+++ b/go/path_srv/internal/handlers/segreqnoncore.go
@@ -119,9 +119,7 @@ func (h *segReqNonCoreHandler) handleCoreDst(ctx context.Context, segReq *path_m
 	}
 	// TODO(lukedirtwalker): in case of CacheOnly we can use a single query,
 	// else we should start go routines for the core segs here.
-	var coreSegs []*seg.PathSegment
-	// All firstIAs of upSegs that are connected, used for filtering later.
-	connFirstIAs := make(map[addr.IA]struct{})
+	var coreSegs seg.Segments
 	// TODO(lukedirtwalker): we shouldn't just query all cores, this could be a lot of overhead.
 	// Add a limit of cores we query.
 	for _, src := range upSegs.FirstIAs() {
@@ -133,18 +131,13 @@ func (h *segReqNonCoreHandler) handleCoreDst(ctx context.Context, segReq *path_m
 			}
 			if len(res) > 0 {
 				coreSegs = append(coreSegs, res...)
-				connFirstIAs[src] = struct{}{}
 			}
-		} else {
-			connFirstIAs[src] = struct{}{}
 		}
 	}
-	// Make sure we only return connected segments.
-	upSegs.FilterSegs(func(s *seg.PathSegment) bool {
-		_, connected := connFirstIAs[s.FirstIA()]
-		return connected
-	})
-	logger.Debug("[segReqHandler] found", "up", len(upSegs), "core", len(coreSegs))
+
+	logger.Debug("[segReqHandler] found segs", "up", len(upSegs), "core", len(coreSegs))
+	selectConnectedSegs(&upSegs, &coreSegs, nil, h.localIA, dst)
+	logger.Debug("[segReqHandler] returning segs", "up", len(upSegs), "core", len(coreSegs))
 	h.sendReply(ctx, msger, upSegs, coreSegs, nil, segReq)
 }
 
@@ -172,10 +165,8 @@ func (h *segReqNonCoreHandler) handleNonCoreDst(ctx context.Context, segReq *pat
 		h.sendEmptySegReply(ctx, segReq, msger)
 		return
 	}
-	var coreSegs []*seg.PathSegment
-	// All firstIAs of up-/down-Segs that are connected, used for filtering later.
-	connUpFirstIAs := make(map[addr.IA]struct{})
-	connDownFirstIAs := make(map[addr.IA]struct{})
+
+	var coreSegs seg.Segments
 	// TODO(lukedirtwalker): in case of CacheOnly we can use a single query,
 	// else we should start go routines for the core segs here.
 	for _, dst := range downSegs.FirstIAs() {
@@ -183,8 +174,6 @@ func (h *segReqNonCoreHandler) handleNonCoreDst(ctx context.Context, segReq *pat
 		// Add a limit of cores we query.
 		for _, src := range upSegs.FirstIAs() {
 			if src.Eq(dst) {
-				connUpFirstIAs[src] = struct{}{}
-				connDownFirstIAs[dst] = struct{}{}
 				continue
 			}
 			cs, err := h.fetchCoreSegs(ctx, msger, src, dst, segReq.Flags.CacheOnly)
@@ -192,24 +181,13 @@ func (h *segReqNonCoreHandler) handleNonCoreDst(ctx context.Context, segReq *pat
 				logger.Error("Failed to find core segs", "src", src, "dst", dst, "err", err)
 				continue
 			}
-			if len(cs) > 0 {
-				coreSegs = append(coreSegs, cs...)
-				connUpFirstIAs[src] = struct{}{}
-				connDownFirstIAs[dst] = struct{}{}
-			}
+			coreSegs = append(coreSegs, cs...)
 		}
 	}
-	// Make sure we only return connected segments.
-	// No need to filter cores, since we only query for connected ones.
-	upSegs.FilterSegs(func(s *seg.PathSegment) bool {
-		_, connected := connUpFirstIAs[s.FirstIA()]
-		return connected
-	})
-	downSegs.FilterSegs(func(s *seg.PathSegment) bool {
-		_, connected := connDownFirstIAs[s.FirstIA()]
-		return connected
-	})
 	logger.Debug("[segReqHandler:handleNonCoreDst] found segs",
+		"up", len(upSegs), "core", len(coreSegs), "down", len(downSegs))
+	selectConnectedSegs(&upSegs, &coreSegs, &downSegs, h.localIA, dstIA)
+	logger.Debug("[segReqHandler:handleNonCoreDst] returning segs",
 		"up", len(upSegs), "core", len(coreSegs), "down", len(downSegs))
 	h.sendReply(ctx, msger, upSegs, coreSegs, downSegs, segReq)
 }

--- a/go/path_srv/internal/handlers/segreqnoncore_test.go
+++ b/go/path_srv/internal/handlers/segreqnoncore_test.go
@@ -51,6 +51,8 @@ var (
 	core1_110 = xtest.MustParseIA("1-ff00:0:110")
 	core1_130 = xtest.MustParseIA("1-ff00:0:130")
 	core1_120 = xtest.MustParseIA("1-ff00:0:120")
+	core1_any = xtest.MustParseIA("1-0")
+	as1_112   = xtest.MustParseIA("1-ff00:0:112")
 	as1_132   = xtest.MustParseIA("1-ff00:0:132")
 
 	core2_210 = xtest.MustParseIA("2-ff00:0:210")
@@ -59,10 +61,12 @@ var (
 	as2_221   = xtest.MustParseIA("2-ff00:0:221")
 	as2_222   = xtest.MustParseIA("2-ff00:0:222")
 
-	seg130_132 = g.Beacon([]common.IFIDType{graph.If_130_A_131_X, graph.If_131_X_132_X})
 	seg110_130 = g.Beacon([]common.IFIDType{graph.If_110_X_130_A})
+	seg120_112 = g.Beacon([]common.IFIDType{graph.If_120_X_111_B, graph.If_111_A_112_X})
+	seg120_130 = g.Beacon([]common.IFIDType{graph.If_120_A_130_B})
 	seg120_210 = g.Beacon([]common.IFIDType{graph.If_120_B_220_X, graph.If_220_X_210_X})
 	seg120_220 = g.Beacon([]common.IFIDType{graph.If_120_B_220_X})
+	seg130_132 = g.Beacon([]common.IFIDType{graph.If_130_A_131_X, graph.If_131_X_132_X})
 
 	seg210_211 = g.Beacon([]common.IFIDType{graph.If_210_X_211_A})
 	seg210_220 = g.Beacon([]common.IFIDType{graph.If_210_X_220_X})
@@ -203,6 +207,15 @@ func TestSegReqLocal(t *testing.T) {
 				[]*seg.PathSegment{seg110_130}, nil),
 		},
 		{
+			Name:  "CoreDST: Single up, dst: core local wildcard",
+			SrcIA: as1_132,
+			DstIA: core1_any,
+			Ups:   []*seg.PathSegment{seg130_132},
+			Cores: []*seg.PathSegment{seg110_130, seg120_130},
+			Expected: expectedSegs([]*seg.PathSegment{seg130_132},
+				[]*seg.PathSegment{seg110_130, seg120_130}, nil),
+		},
+		{
 			Name:  "CoreDST: Single up, dst: core remote",
 			SrcIA: as1_132,
 			DstIA: core2_220,
@@ -238,10 +251,10 @@ func TestSegReqLocal(t *testing.T) {
 		},
 		{
 			Name:     "NonCoreDST: Single up, no core, single down",
-			SrcIA:    as2_222,
-			DstIA:    as2_211,
-			Ups:      []*seg.PathSegment{seg220_222},
-			Downs:    []*seg.PathSegment{seg210_211},
+			SrcIA:    as1_132,
+			DstIA:    as1_112,
+			Ups:      []*seg.PathSegment{seg130_132},
+			Downs:    []*seg.PathSegment{seg120_112},
 			Expected: expectedSegs(nil, nil, nil),
 		},
 		{
@@ -253,6 +266,15 @@ func TestSegReqLocal(t *testing.T) {
 			Downs: []*seg.PathSegment{seg210_211},
 			Expected: expectedSegs([]*seg.PathSegment{seg220_222},
 				[]*seg.PathSegment{seg210_220}, []*seg.PathSegment{seg210_211}),
+		},
+		{
+			Name:  "NonCoreDST: Single up, no core, single down with peering",
+			SrcIA: as2_222,
+			DstIA: as2_211,
+			Ups:   []*seg.PathSegment{seg220_222},
+			Downs: []*seg.PathSegment{seg210_211},
+			Expected: expectedSegs([]*seg.PathSegment{seg220_222}, nil,
+				[]*seg.PathSegment{seg210_211}),
 		},
 		{
 			Name:  "NonCoreDst: On up path dst",


### PR DESCRIPTION
Return segments corresponding to connected paths with least number of
hops, using path combinator to find valid combinations of segments.

See scionproto/scion#2452 -- will most likely not be merged in upstream as a larger reorganization of the PS lookups is planned (scionproto/scion#2454).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/netsec-scion/23)
<!-- Reviewable:end -->
