### PR TITLE
Add verbose flag for Hop Fields to showpaths

### DIFF
--- a/go/lib/spath/path.go
+++ b/go/lib/spath/path.go
@@ -161,7 +161,7 @@ func (path *Path) IsEmpty() bool {
 	return path == nil || len(path.Raw) == 0
 }
 
-// incOffsetsRaw jumps ahead skip bytes, but DOES NOT by default skip VerifyOnly HF,
+// IncOffsetsRaw jumps ahead skip bytes, but DOES NOT by default skip VerifyOnly HF,
 // and searches for the first Hop Field starting at that location
 func (path *Path) IncOffsetsRaw(skip int, skipVerify bool) error {
 	var hopF *HopField

--- a/go/lib/spath/path.go
+++ b/go/lib/spath/path.go
@@ -161,9 +161,9 @@ func (path *Path) IsEmpty() bool {
 	return path == nil || len(path.Raw) == 0
 }
 
-// incOffsets jumps ahead skip bytes, and searches for the first routing Hop
-// Field starting at that location
-func (path *Path) incOffsets(skip int) error {
+// incOffsetsRaw jumps ahead skip bytes, but DOES NOT by default skip VerifyOnly HF,
+// and searches for the first Hop Field starting at that location
+func (path *Path) IncOffsetsRaw(skip int, skipVerify bool) error {
 	var hopF *HopField
 	infoF, err := path.GetInfoField(path.InfOff)
 	if err != nil {
@@ -183,12 +183,24 @@ func (path *Path) incOffsets(skip int) error {
 		if hopF, err = path.GetHopField(path.HopOff); err != nil {
 			return common.NewBasicError("Hop Field parse error", err, "offset", path.HopOff)
 		}
-		if !hopF.VerifyOnly {
+		if !skipVerify || !hopF.VerifyOnly {
 			break
 		}
 		path.HopOff += HopFieldLength
 	}
 	return nil
+}
+
+// incOffsets jumps ahead skip bytes, and searches for the first routing Hop
+// Field starting at that location
+func (path *Path) incOffsets(skip int) error {
+	return path.IncOffsetsRaw(skip, true)
+}
+
+// incOffsetsAny jumps ahead skip bytes, and searches for the first Verify/Routing/any Hop
+// Field starting at that location
+func (path *Path) incOffsetsAny(skip int) error {
+	return path.IncOffsetsRaw(skip, false)
 }
 
 func (path *Path) GetInfoField(offset int) (*InfoField, error) {

--- a/go/tools/showpaths/paths.go
+++ b/go/tools/showpaths/paths.go
@@ -128,7 +128,7 @@ func printHFDetails(i int, path sciond.PathReplyEntry) {
 		if hf.VerifyOnly {
 			VerifyOnlyVal = "V"
 		}
-		fmt.Printf("\n\tHF %s%s InIF: %v OutIF: %v \t\t\tExpTime: %v Mac: %v",
+		fmt.Printf("\n\tHF %s%s InIF: %3v OutIF: %3v \t\t\tExpTime: %v Mac: %v",
 			XoverVal, VerifyOnlyVal, hf.ConsIngress, hf.ConsEgress, hf.ExpTime, hf.Mac)
 		vpath.IncOffsetsRaw(spath.HopFieldLength, false)
 	}

--- a/go/tools/showpaths/paths.go
+++ b/go/tools/showpaths/paths.go
@@ -44,7 +44,9 @@ var (
 	expiration   = flag.Bool("expiration", false, "Show path expiration timestamps")
 	refresh      = flag.Bool("refresh", false, "Set refresh flag for SCIOND path request")
 	status       = flag.Bool("p", false, "Probe the paths and print out the statuses")
-	version      = flag.Bool("version", false, "Output version information and exit.")
+	verbose      = flag.Bool("v", false, "Switch to verbose output and show additional "+
+		"information about paths.")
+	version = flag.Bool("version", false, "Output version information and exit.")
 )
 
 var (
@@ -90,6 +92,7 @@ func main() {
 	}
 	for i, path := range reply.Entries {
 		fmt.Printf("[%2d] %s", i, path.Path.String())
+
 		if *expiration {
 			fmt.Printf(" Expires: %s (%s)", path.Path.Expiry(),
 				time.Until(path.Path.Expiry()).Truncate(time.Second))
@@ -97,8 +100,39 @@ func main() {
 		if *status {
 			fmt.Printf(" Status: %s", pathStatuses[string(path.Path.FwdPath)])
 		}
+		if *verbose {
+			printHFDetails(i, path)
+		}
 		fmt.Printf("\n")
 	}
+}
+
+func printHFDetails(i int, path sciond.PathReplyEntry) {
+	vpath := &spath.Path{Raw: path.Path.FwdPath}
+	vpath.HopOff = common.LineLen // skip InfoField, cannot use vpath.InitOffsets() as it skips more
+	fmt.Printf("\nPath #%2d:\n Fields:", i)
+	for {
+		if vpath.HopOff == len(path.Path.FwdPath) {
+			break
+		}
+		hf, err := vpath.GetHopField(vpath.HopOff)
+		if err != nil {
+			fmt.Printf("\n\nGetHopField err:%v", err)
+			break
+		}
+		XoverVal := "."
+		if hf.Xover {
+			XoverVal = "X"
+		}
+		VerifyOnlyVal := "."
+		if hf.VerifyOnly {
+			VerifyOnlyVal = "V"
+		}
+		fmt.Printf("\n\tHF %s%s InIF: %v OutIF: %v \t\t\tExpTime: %v Mac: %v",
+			XoverVal, VerifyOnlyVal, hf.ConsIngress, hf.ConsEgress, hf.ExpTime, hf.Mac)
+		vpath.IncOffsetsRaw(spath.HopFieldLength, false)
+	}
+	fmt.Println()
 }
 
 func validateFlags() {


### PR DESCRIPTION
Updates spath incOffsets for the Hop Field offset increment to allow NOT skipping non routing Hop Fields.
Add a flag to showpaths that uses this to show details about the Hop Fields of a path.
Is useful to verify that paths that look identical at the Interface level are different at the Hop Field level.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/netsec-scion/25)
<!-- Reviewable:end -->
