### PR TITLE
Fast path handling for IFIDs

### DIFF
--- a/python/beacon_server/base.py
+++ b/python/beacon_server/base.py
@@ -436,7 +436,10 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
         pld = cpld.union
         assert isinstance(pld, IFIDPayload), type(pld)
         ifid = meta.pkt.path.get_hof().ingress_if
-        # Note: No self.ifid_state_lock; the state will not change
+        # Note: No self.ifid_state_lock; the lock is to guard against concurrent
+        # changes of the state of interfaces and this won't change the state.
+        # Also, no entries are added to or removed from ifid_state after
+        # startup.
         if ifid not in self.ifid_state:
             raise SCIONKeyError("Invalid IF %d in IFIDPayload" % ifid)
         return self.ifid_state[ifid].update_active()

--- a/python/beacon_server/base.py
+++ b/python/beacon_server/base.py
@@ -436,10 +436,10 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
         pld = cpld.union
         assert isinstance(pld, IFIDPayload), type(pld)
         ifid = meta.pkt.path.get_hof().ingress_if
-        with self.ifid_state_lock:
-            if ifid not in self.ifid_state:
-                raise SCIONKeyError("Invalid IF %d in IFIDPayload" % ifid)
-            return self.ifid_state[ifid].update_active()
+        # Note: No self.ifid_state_lock; the state will not change
+        if ifid not in self.ifid_state:
+            raise SCIONKeyError("Invalid IF %d in IFIDPayload" % ifid)
+        return self.ifid_state[ifid].update_active()
 
     def handle_ifid_packet(self, cpld, meta):
         """

--- a/python/beacon_server/base.py
+++ b/python/beacon_server/base.py
@@ -168,6 +168,9 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
                 PMT.REVOCATION: self._handle_revocation,
             },
         }
+        self.CTRL_PLD_CLASS_FAST_MAP = {
+            PayloadClass.IFID: {PayloadClass.IFID: self.try_fast_handle_ifid_packet},
+        }
         self.SCMP_PLD_CLASS_MAP = {
             SCMPClass.PATH: {
                 SCMPPathClass.REVOKED_IF: self._handle_scmp_revocation,
@@ -411,6 +414,32 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
             return None
         pcb.add_asm(asm, ProtoSignType.ED25519, self.addr.isd_as.pack())
         return pcb
+
+    def try_fast_handle_ifid_packet(self, cpld, meta):
+        """
+        Update the last_updated timestamp for the corresponding interface.
+        If the interface is not currently active (i.e. it will be activated by
+        this IFID packet), the packet will NOT be handled (returns False).
+
+        Note: updating the timestamp is very cheap (same order of magnitude as
+        enqueuing the packet for asynchronous processing), so it can safely be
+        done on the packet-receive thread.
+        This helps to process IFID packets for active interfaces in time, as it
+        and avoids the problem that interfaces time out because the IFIDs are
+        stuck in a long packet processing queue (behind PCBs).
+        For inactive interfaces, the processing of the IFIDs is more work as
+        state updates will be sent out. Also, this is not time-critical as the
+        interface is, well, down.
+
+        :returns: has the packet been handled
+        """
+        pld = cpld.union
+        assert isinstance(pld, IFIDPayload), type(pld)
+        ifid = meta.pkt.path.get_hof().ingress_if
+        with self.ifid_state_lock:
+            if ifid not in self.ifid_state:
+                raise SCIONKeyError("Invalid IF %d in IFIDPayload" % ifid)
+            return self.ifid_state[ifid].update_active()
 
     def handle_ifid_packet(self, cpld, meta):
         """

--- a/python/beacon_server/if_state.py
+++ b/python/beacon_server/if_state.py
@@ -64,7 +64,7 @@ class InterfaceState(object):
         """
         with self._lock:
             curr_time = time.time()
-            if self._state != self.ACTIVE:
+            if self._state == self.ACTIVE:
                 self.last_updated = curr_time
                 return True
             return False

--- a/python/beacon_server/if_state.py
+++ b/python/beacon_server/if_state.py
@@ -57,6 +57,18 @@ class InterfaceState(object):
             self.last_updated = curr_time
             return prev_state
 
+    def update_active(self):
+        """
+        Updates the last_updated timestamp *iff* the object is currently
+        in the active state. Returns True iff the object is active.
+        """
+        with self._lock:
+            curr_time = time.time()
+            if self._state != self.ACTIVE:
+                self.last_updated = curr_time
+                return True
+            return False
+
     def reset(self):
         """
         Resets the state of an InterfaceState object.

--- a/python/scion_elem/scion_elem.py
+++ b/python/scion_elem/scion_elem.py
@@ -752,7 +752,7 @@ class SCIONElement(object):
         Return optional fast path handler.
         """
         pclass = msg.type()
-        type_map = self.CTRL_PLD_CLASS_MAP.get(pclass)
+        type_map = self.CTRL_PLD_CLASS_FAST_MAP.get(pclass)
         if not type_map:
             return None
         ptype = msg.inner_type()

--- a/python/scion_elem/scion_elem.py
+++ b/python/scion_elem/scion_elem.py
@@ -168,6 +168,7 @@ class SCIONElement(object):
         self._labels = {"server_id": self.id, "isd_as": str(self.topology.isd_as)}
         # Must be over-ridden by child classes:
         self.CTRL_PLD_CLASS_MAP = {}
+        self.CTRL_PLD_CLASS_FAST_MAP = {}
         self.SCMP_PLD_CLASS_MAP = {}
         self.public = public
         self.bind = bind
@@ -746,6 +747,17 @@ class SCIONElement(object):
             logging.error("%s control payload type not supported: %s\n%s", pclass, ptype, msg)
         return None
 
+    def _get_fast_ctrl_handler(self, msg):
+        """
+        Return optional fast path handler.
+        """
+        pclass = msg.type()
+        type_map = self.CTRL_PLD_CLASS_MAP.get(pclass)
+        if not type_map:
+            return None
+        ptype = msg.inner_type()
+        return type_map.get(ptype)
+
     def _get_scmp_handler(self, pkt):
         scmp = pkt.l4_hdr
         try:
@@ -1049,7 +1061,21 @@ class SCIONElement(object):
                 if self._labels:
                     CONNECTED_TO_DISPATCHER.labels(**self._labels).set(0)
             return
-        self.packet_put(packet, addr, sock)
+
+        msg, meta = self._get_msg_meta(packet, addr, sock)
+        if msg is None:
+            return
+
+        # Try to handle immediately if supported for this message type:
+        handled = False
+        if isinstance(meta, UDPMetadata):
+            fast_handler = self._get_fast_ctrl_handler(msg)
+            if fast_handler:
+                handled = fast_handler(msg, meta)
+
+        # If no fast-path handler for this message OR handler explicitly skipped, enqueue:
+        if not handled:
+            self._in_buf_put((msg, meta))
 
     def packet_recv(self):
         """


### PR DESCRIPTION
Updating the timestamp is very cheap (same order of magnitude as        enqueuing the packet for asynchronous processing), so it can safely be        done on the packet-receive thread.
        This helps to process IFID packets for active interfaces in time, as it        and avoids the problem that interfaces time out because the IFIDs are        stuck in a long packet processing queue (behind PCBs).
        For inactive interfaces, the processing of the IFIDs is more work as        state updates will be sent out. Also, this is not time-critical as the        interface is, well, down.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/netsec-scion/27)
<!-- Reviewable:end -->
