### PR TITLE
Control plane buffer size also to 64K.

### DIFF
--- a/go/border/rctrl/ctrl.go
+++ b/go/border/rctrl/ctrl.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	maxBufSize = 9 * 1024
+	maxBufSize = 64 * 1024
 )
 
 var (


### PR DESCRIPTION
When sending big IFState packets from the BS to the BR, the BR will need
more room in its buffer. This is a similar patch to the one applied in
the data plane via PR #21.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/netsec-scion/28)
<!-- Reviewable:end -->
