### PR TITLE
Same log sample section for all

### DIFF
--- a/go/cert_srv/internal/csconfig/conf_test.go
+++ b/go/cert_srv/internal/csconfig/conf_test.go
@@ -49,6 +49,9 @@ func TestSampleCorrect(t *testing.T) {
 		SoMsg("LogFile correct", cfg.Logging.File.Path, ShouldEqual, "/var/log/scion/cs-1.log")
 		SoMsg("LogLvl correct", cfg.Logging.File.Level, ShouldEqual, "debug")
 		SoMsg("LogFlush correct", *cfg.Logging.File.FlushInterval, ShouldEqual, 5)
+		SoMsg("Size correct", cfg.Logging.File.Size, ShouldEqual, 50)
+		SoMsg("MaxAge correct", cfg.Logging.File.MaxAge, ShouldEqual, 7)
+		SoMsg("MaxCount correct", cfg.Logging.File.MaxCount, ShouldEqual, 3)
 		SoMsg("LogConsoleLvl correct", cfg.Logging.Console.Level, ShouldEqual, "crit")
 		SoMsg("TrustDB.Backend correct", cfg.TrustDB.Backend, ShouldEqual, "sqlite")
 		SoMsg("TrustDB.Connection correct", cfg.TrustDB.Connection, ShouldEqual,

--- a/go/cert_srv/internal/csconfig/sample.go
+++ b/go/cert_srv/internal/csconfig/sample.go
@@ -45,13 +45,13 @@ const Sample = `[general]
     Level = "debug"
 
     # Max size of log file in MiB (default 50)
-    # Size = 50
+    Size = 50
 
     # Max age of log file in days (default 7)
-    # MaxAge = 7
+    MaxAge = 7
 
     # Max count of old log files (default 3)
-    # MaxCount = 3
+    MaxCount = 3
 
     # How frequently to flush to the log file, in seconds. If 0, all messages
     # are immediately flushed. If negative, messages are never flushed

--- a/go/cert_srv/internal/csconfig/sample.go
+++ b/go/cert_srv/internal/csconfig/sample.go
@@ -50,6 +50,9 @@ const Sample = `[general]
     # Max age of log file in days (default 7)
     # MaxAge = 7
 
+    # Max count of old log files (default 3)
+    MaxCount = 3
+
     # How frequently to flush to the log file, in seconds. If 0, all messages
     # are immediately flushed. If negative, messages are never flushed
     # automatically. (default 5)

--- a/go/cert_srv/internal/csconfig/sample.go
+++ b/go/cert_srv/internal/csconfig/sample.go
@@ -51,7 +51,7 @@ const Sample = `[general]
     # MaxAge = 7
 
     # Max count of old log files (default 3)
-    MaxCount = 3
+    # MaxCount = 3
 
     # How frequently to flush to the log file, in seconds. If 0, all messages
     # are immediately flushed. If negative, messages are never flushed

--- a/go/path_srv/internal/psconfig/sample.go
+++ b/go/path_srv/internal/psconfig/sample.go
@@ -44,7 +44,7 @@ const Sample = `[general]
     MaxAge = 7
 
     # Max count of old log files (default 3)
-    MaxCount = 3
+    # MaxCount = 3
 
     # How frequently to flush to the log file, in seconds. If 0, all messages
     # are immediately flushed. If negative, messages are never flushed

--- a/go/path_srv/internal/psconfig/sample.go
+++ b/go/path_srv/internal/psconfig/sample.go
@@ -38,13 +38,13 @@ const Sample = `[general]
     Level = "debug"
 
     # Max size of log file in MiB (default 50)
-    # Size = 50
+    Size = 50
 
     # Max age of log file in days (default 7)
     MaxAge = 7
 
     # Max count of old log files (default 3)
-    # MaxCount = 3
+    MaxCount = 3
 
     # How frequently to flush to the log file, in seconds. If 0, all messages
     # are immediately flushed. If negative, messages are never flushed

--- a/go/path_srv/internal/psconfig/sample_test.go
+++ b/go/path_srv/internal/psconfig/sample_test.go
@@ -48,6 +48,7 @@ func TestSampleCorrect(t *testing.T) {
 		SoMsg("LogFile correct", cfg.Logging.File.Path, ShouldEqual, "/var/log/scion/ps-1.log")
 		SoMsg("LogLvl correct", cfg.Logging.File.Level, ShouldEqual, "debug")
 		SoMsg("LogFlush correct", *cfg.Logging.File.FlushInterval, ShouldEqual, 5)
+		SoMsg("Size correct", cfg.Logging.File.Size, ShouldEqual, 50)
 		SoMsg("MaxAge correct", cfg.Logging.File.MaxAge, ShouldEqual, 7)
 		SoMsg("MaxCount correct", cfg.Logging.File.MaxCount, ShouldEqual, 3)
 		SoMsg("LogConsoleLvl correct", cfg.Logging.Console.Level, ShouldEqual, "crit")

--- a/go/sciond/internal/sdconfig/sample.go
+++ b/go/sciond/internal/sdconfig/sample.go
@@ -37,13 +37,13 @@ const Sample = `[general]
     Level = "debug"
 
     # Max size of log file in MiB (default 50)
-    # Size = 50
+    Size = 50
 
     # Max age of log file in days (default 7)
-    # MaxAge = 7
+    MaxAge = 7
 
     # Max count of old log files (default 3)
-    # MaxCount = 3
+    MaxCount = 3
 
     # How frequently to flush to the log file, in seconds. If 0, all messages
     # are immediately flushed. If negative, messages are never flushed

--- a/go/sciond/internal/sdconfig/sample.go
+++ b/go/sciond/internal/sdconfig/sample.go
@@ -42,6 +42,9 @@ const Sample = `[general]
     # Max age of log file in days (default 7)
     # MaxAge = 7
 
+    # Max count of old log files (default 3)
+    MaxCount = 3
+
     # How frequently to flush to the log file, in seconds. If 0, all messages
     # are immediately flushed. If negative, messages are never flushed
     # automatically. (default 5)

--- a/go/sciond/internal/sdconfig/sample.go
+++ b/go/sciond/internal/sdconfig/sample.go
@@ -43,7 +43,7 @@ const Sample = `[general]
     # MaxAge = 7
 
     # Max count of old log files (default 3)
-    MaxCount = 3
+    # MaxCount = 3
 
     # How frequently to flush to the log file, in seconds. If 0, all messages
     # are immediately flushed. If negative, messages are never flushed

--- a/go/sciond/internal/sdconfig/sample_test.go
+++ b/go/sciond/internal/sdconfig/sample_test.go
@@ -48,6 +48,9 @@ func TestSampleCorrect(t *testing.T) {
 		SoMsg("LogFile correct", cfg.Logging.File.Path, ShouldEqual, "/var/log/scion/sd.log")
 		SoMsg("LogLvl correct", cfg.Logging.File.Level, ShouldEqual, "debug")
 		SoMsg("LogFlush correct", *cfg.Logging.File.FlushInterval, ShouldEqual, 5)
+		SoMsg("Size correct", cfg.Logging.File.Size, ShouldEqual, 50)
+		SoMsg("MaxAge correct", cfg.Logging.File.MaxAge, ShouldEqual, 7)
+		SoMsg("MaxCount correct", cfg.Logging.File.MaxCount, ShouldEqual, 3)
 		SoMsg("LogConsoleLvl correct", cfg.Logging.Console.Level, ShouldEqual, "crit")
 		SoMsg("TrustDB.Backend correct", cfg.TrustDB.Backend, ShouldEqual, "sqlite")
 		SoMsg("TrustDB.Connection correct", cfg.TrustDB.Connection,

--- a/go/sig/internal/sigconfig/conf_test.go
+++ b/go/sig/internal/sigconfig/conf_test.go
@@ -62,6 +62,9 @@ func TestSample(t *testing.T) {
 		SoMsg("LogFile correct", cfg.Logging.File.Path, ShouldEqual, "/var/log/scion/sig4.log")
 		SoMsg("LogLvl correct", cfg.Logging.File.Level, ShouldEqual, "debug")
 		SoMsg("LogFlush correct", *cfg.Logging.File.FlushInterval, ShouldEqual, 5)
+		SoMsg("Size correct", cfg.Logging.File.Size, ShouldEqual, 50)
+		SoMsg("MaxAge correct", cfg.Logging.File.MaxAge, ShouldEqual, 7)
+		SoMsg("MaxCount correct", cfg.Logging.File.MaxCount, ShouldEqual, 3)
 		SoMsg("LogConsoleLvl correct", cfg.Logging.Console.Level, ShouldEqual, "crit")
 
 		// Metrics

--- a/go/sig/internal/sigconfig/sample.go
+++ b/go/sig/internal/sigconfig/sample.go
@@ -65,7 +65,7 @@ const Sample = `
   # MaxAge = 7
 
   # Max count of old log files (default 3)
-  MaxCount = 3
+  # MaxCount = 3
 
   # How frequently to flush to the log file, in seconds. If 0, all messages
   # are immediately flushed. If negative, messages are never flushed

--- a/go/sig/internal/sigconfig/sample.go
+++ b/go/sig/internal/sigconfig/sample.go
@@ -64,6 +64,9 @@ const Sample = `
   # Max age of log file in days (default 7)
   # MaxAge = 7
 
+  # Max count of old log files (default 3)
+  MaxCount = 3
+
   # How frequently to flush to the log file, in seconds. If 0, all messages
   # are immediately flushed. If negative, messages are never flushed
   # automatically. (default 5)

--- a/go/sig/internal/sigconfig/sample.go
+++ b/go/sig/internal/sigconfig/sample.go
@@ -59,13 +59,13 @@ const Sample = `
   Level = "debug"
 
   # Max size of log file in MiB (default 50)
-  # Size = 50
+  Size = 50
 
   # Max age of log file in days (default 7)
-  # MaxAge = 7
+  MaxAge = 7
 
   # Max count of old log files (default 3)
-  # MaxCount = 3
+  MaxCount = 3
 
   # How frequently to flush to the log file, in seconds. If 0, all messages
   # are immediately flushed. If negative, messages are never flushed


### PR DESCRIPTION
Leave the log section identical for all the toml configuration samples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/netsec-scion/30)
<!-- Reviewable:end -->
