### PR TITLE
Accept a parameter to avoid calling docker compose.

### DIFF
--- a/scion.sh
+++ b/scion.sh
@@ -9,6 +9,11 @@ EXTRA_NOSE_ARGS="-w python/ --with-xunit --xunit-file=logs/nosetests.xml"
 cmd_topology() {
     set -e
     local zkclean
+    local avoid_zk_docker
+    if [ "$1" = "nodocker" ]; then
+        shift
+        avoid_zk_docker=1
+    fi
     if is_docker_be; then
         echo "Shutting down dockerized topology..."
         ./tools/quiet ./tools/dc down
@@ -25,6 +30,10 @@ cmd_topology() {
     echo "Create topology, configuration, and execution files."
     is_running_in_docker && set -- "$@" --in-docker
     python/topology/generator.py "$@"
+    if [ "$avoid_zk_docker" = 1 ]; then
+        # we don't want to run docker compose when calling run_zk
+        rm -f gen/scion-dc.yml gen/zk-dc.yml
+    fi
     if is_docker_be; then
         ./tools/quiet ./tools/dc run utils_chowner
     fi


### PR DESCRIPTION
After generating a new topology the file zk-dc.yml always exists. Accept a parameger when
calling 'topology' to remove said fail right after generating the new topology. This
will prevent run_zk from calling docker compose.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/netsec-scion/31)
<!-- Reviewable:end -->
