### PR TITLE
Ignore missing gen/overlay file

### DIFF
--- a/python/integration/set_ipv6_addr.py
+++ b/python/integration/set_ipv6_addr.py
@@ -19,6 +19,7 @@ import argparse
 from ipaddress import IPv6Address, IPv6Network
 
 # SCION
+import lib.errors
 from lib.defines import (
     GEN_PATH,
     DEFAULT6_CLIENT,
@@ -64,12 +65,15 @@ def set_interfaces():
 
 def get_overlay():
     file_path = os.path.join(GEN_PATH, OVERLAY_FILE)
-    return read_file(file_path).strip()
+    try:
+        return read_file(file_path).strip()
+    except(lib.errors.SCIONIOError):
+        return None
 
 
 def main():
     overlay = get_overlay()
-    if "IPv4" in overlay:
+    if overlay is None or "IPv4" in overlay:
         return
 
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
A utility for the integration tests fails loudly during `scion.sh start` if this `gen/overlay` is missing, but this has no effect whatsoever for actually running scion.
Allows to not include this otherwise useless file in the scionlab config tarball.

Fixes netsec-ethz/scionlab#87

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/netsec-scion/35)
<!-- Reviewable:end -->
