### PR TITLE
Fix typo in error handling

### DIFF
--- a/python/scion_elem/scion_elem.py
+++ b/python/scion_elem/scion_elem.py
@@ -713,7 +713,7 @@ class SCIONElement(object):
             cert_ia = asm.isd_as()
             trc = self.trust_store.get_trc(cert_ia[0], asm.p.trcVer)
             if not trc:
-                logging.error("Could not get TRC %sv%s" (cert_ia[0], asm.p.trcVer))
+                logging.error("Could not get TRC %sv%s" % (cert_ia[0], asm.p.trcVer))
                 continue
             chain = self.trust_store.get_cert(asm.isd_as(), asm.p.certVer)
             if not chain:


### PR DESCRIPTION
Prevents the BS from crashing when the previous TRC cannot be found

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/netsec-scion/36)
<!-- Reviewable:end -->
