### PR TITLE
Use system zookeeper by default in local topo

### DIFF
--- a/python/topology/zk.py
+++ b/python/topology/zk.py
@@ -36,6 +36,8 @@ class ZKGenerator(object):
         self.zk_conf = {'version': '3', 'services': {}}
 
     def generate(self):
+        if not self.args.docker:
+            return
         # Take first topo_id as zookeeper is the same for all topos
         topo_id = next(iter(self.args.topo_dicts))
         zk_entry = self.args.topo_dicts[topo_id]["ZookeeperService"][1]

--- a/scion.sh
+++ b/scion.sh
@@ -9,11 +9,6 @@ EXTRA_NOSE_ARGS="-w python/ --with-xunit --xunit-file=logs/nosetests.xml"
 cmd_topology() {
     set -e
     local zkclean
-    local avoid_zk_docker
-    if [ "$1" = "nodocker" ]; then
-        shift
-        avoid_zk_docker=1
-    fi
     if is_docker_be; then
         echo "Shutting down dockerized topology..."
         ./tools/quiet ./tools/dc down
@@ -30,10 +25,6 @@ cmd_topology() {
     echo "Create topology, configuration, and execution files."
     is_running_in_docker && set -- "$@" --in-docker
     python/topology/generator.py "$@"
-    if [ "$avoid_zk_docker" = 1 ]; then
-        # we don't want to run docker compose when calling run_zk
-        rm -f gen/scion-dc.yml gen/zk-dc.yml
-    fi
     if is_docker_be; then
         ./tools/quiet ./tools/dc run utils_chowner
     fi


### PR DESCRIPTION
Don't create zk-dc.yaml in topology creation so that `scion.sh start` will default to start the system zookeeper.

This is a follow up on #19.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/netsec-scion/40)
<!-- Reviewable:end -->
