### PR TITLE
Prevent BS crash.

### DIFF
--- a/python/lib/packet/packet_base.py
+++ b/python/lib/packet/packet_base.py
@@ -197,10 +197,15 @@ class CerealBox(object, metaclass=ABCMeta):
         capnp object. The appropriate python class is selected by looking up the union field name in
         CLASS_FIELD_MAP.
         """
-        type_ = p.which()
-        for cls_, field in cls.CLASS_FIELD_MAP.items():
-            if type_ == field:
-                return cls._from_union(p, cls_.from_proto(getattr(p, type_)))
+        type_ = "Unassigned"
+        try:
+            type_ = p.which()
+            for cls_, field in cls.CLASS_FIELD_MAP.items():
+                if type_ == field:
+                    return cls._from_union(p, cls_.from_proto(getattr(p, type_)))
+        except:
+            pass
+
         raise SCIONParseError("Unsupported %s proto type: %s" % (cls.NAME, type_))
 
     @classmethod

--- a/python/lib/packet/packet_base.py
+++ b/python/lib/packet/packet_base.py
@@ -197,15 +197,13 @@ class CerealBox(object, metaclass=ABCMeta):
         capnp object. The appropriate python class is selected by looking up the union field name in
         CLASS_FIELD_MAP.
         """
-        type_ = "Unassigned"
         try:
             type_ = p.which()
             for cls_, field in cls.CLASS_FIELD_MAP.items():
                 if type_ == field:
                     return cls._from_union(p, cls_.from_proto(getattr(p, type_)))
-        except:
-            pass
-
+        except capnp.lib.capnp.KjException as e:
+            raise SCIONParseError("Unable to parse %s capnp message: %s" % (cls, e))
         raise SCIONParseError("Unsupported %s proto type: %s" % (cls.NAME, type_))
 
     @classmethod


### PR DESCRIPTION
When running an AS with the next SCIONLab version, the BS in this AS will crash every ~30 secs. Simply avoid the crashing, as it is interesting for us to upgrade machines gradually, and not all at once, if possible.

To test it, e.g. run a user AS following `scionlab_nextversion`, attached to a current `scionlab`. The `BS` of the AP will restart frequently (check with `supervisor.sh status`).

The original exception is:
```
2019-08-20 14:39:07.023691+0000 [CRITICAL] (Elem.packet_recv) Exception in Elem.packet_recv thread:
2019-08-20 14:39:07.028820+0000 [CRITICAL] (Elem.packet_recv) Traceback (most recent call last):
2019-08-20 14:39:07.029960+0000 [CRITICAL] (Elem.packet_recv)   File "capnp/lib/capnp.pyx", line 1354, in capnp.lib.capnp._DynamicStructBuilder._which (capnp/lib/capnp.cpp:28795)
2019-08-20 14:39:07.031095+0000 [CRITICAL] (Elem.packet_recv) RuntimeError: Member was null.
2019-08-20 14:39:07.032293+0000 [CRITICAL] (Elem.packet_recv) 
2019-08-20 14:39:07.033481+0000 [CRITICAL] (Elem.packet_recv) During handling of the above exception, another exception occurred:
2019-08-20 14:39:07.034641+0000 [CRITICAL] (Elem.packet_recv) 
2019-08-20 14:39:07.035804+0000 [CRITICAL] (Elem.packet_recv) Traceback (most recent call last):
2019-08-20 14:39:07.037071+0000 [CRITICAL] (Elem.packet_recv)   File "/home/scion/go/src/github.com/scionproto/scion/python/lib/thread.py", line 49, in thread_safety_net
2019-08-20 14:39:07.038445+0000 [CRITICAL] (Elem.packet_recv)     return func(*args, **kwargs)
2019-08-20 14:39:07.040095+0000 [CRITICAL] (Elem.packet_recv)   File "/home/scion/go/src/github.com/scionproto/scion/python/scion_elem/scion_elem.py", line 1088, in packet_recv
2019-08-20 14:39:07.041227+0000 [CRITICAL] (Elem.packet_recv)     callback(sock)
2019-08-20 14:39:07.042231+0000 [CRITICAL] (Elem.packet_recv)   File "/home/scion/go/src/github.com/scionproto/scion/python/scion_elem/scion_elem.py", line 1065, in handle_recv
2019-08-20 14:39:07.043046+0000 [CRITICAL] (Elem.packet_recv)     msg, meta = self._get_msg_meta(packet, addr, sock)
2019-08-20 14:39:07.044576+0000 [CRITICAL] (Elem.packet_recv)   File "/home/scion/go/src/github.com/scionproto/scion/python/scion_elem/scion_elem.py", line 1031, in _get_msg_meta
2019-08-20 14:39:07.046101+0000 [CRITICAL] (Elem.packet_recv)     pkt.parse_payload()
2019-08-20 14:39:07.047616+0000 [CRITICAL] (Elem.packet_recv)   File "/home/scion/go/src/github.com/scionproto/scion/python/lib/packet/scion.py", line 659, in parse_payload
2019-08-20 14:39:07.049126+0000 [CRITICAL] (Elem.packet_recv)     pld = SignedCtrlPayload.from_raw(praw).pld()
2019-08-20 14:39:07.051842+0000 [CRITICAL] (Elem.packet_recv)   File "/home/scion/go/src/github.com/scionproto/scion/python/lib/packet/ctrl_pld.py", line 78, in pld
2019-08-20 14:39:07.054575+0000 [CRITICAL] (Elem.packet_recv)     return CtrlPayload.from_raw(self.p.blob)
2019-08-20 14:39:07.055606+0000 [CRITICAL] (Elem.packet_recv)   File "/home/scion/go/src/github.com/scionproto/scion/python/lib/packet/ctrl_pld.py", line 107, in from_raw
2019-08-20 14:39:07.056223+0000 [CRITICAL] (Elem.packet_recv)     return cls.from_proto(p)
2019-08-20 14:39:07.057728+0000 [CRITICAL] (Elem.packet_recv)   File "/home/scion/go/src/github.com/scionproto/scion/python/lib/packet/packet_base.py", line 200, in from_proto
2019-08-20 14:39:07.059427+0000 [CRITICAL] (Elem.packet_recv)     type_ = p.which()
2019-08-20 14:39:07.061444+0000 [CRITICAL] (Elem.packet_recv)   File "capnp/lib/capnp.pyx", line 1369, in capnp.lib.capnp._DynamicStructBuilder.which.__get__ (capnp/lib/capnp.cpp:28976)
2019-08-20 14:39:07.062880+0000 [CRITICAL] (Elem.packet_recv)   File "capnp/lib/capnp.pyx", line 1356, in capnp.lib.capnp._DynamicStructBuilder._which (capnp/lib/capnp.cpp:28850)
2019-08-20 14:39:07.064291+0000 [CRITICAL] (Elem.packet_recv) capnp.lib.capnp.KjException: Attempted to call which on a non-union type
2019-08-20 14:39:07.065649+0000 [CRITICAL] (Elem.packet_recv) 
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/netsec-scion/54)
<!-- Reviewable:end -->
