### PR TITLE
Fix zookeeper conf creation in CI

### DIFF
--- a/python/topology/zk.py
+++ b/python/topology/zk.py
@@ -36,7 +36,7 @@ class ZKGenerator(object):
         self.zk_conf = {'version': '3', 'services': {}}
 
     def generate(self):
-        if not self.args.docker:
+        if not self.args.docker and not self.args.in_docker:
             return
         # Take first topo_id as zookeeper is the same for all topos
         topo_id = next(iter(self.args.topo_dicts))


### PR DESCRIPTION
The `zk-dc.yml` file is needed by the integration tests when running inside a docker container.
Use the `args.in_docker` to detect that situation.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/netsec-scion/56)
<!-- Reviewable:end -->
