### PR TITLE
Allow clock drifts up to 10 seconds.

### DIFF
--- a/go/lib/infra/modules/trust/trust.go
+++ b/go/lib/infra/modules/trust/trust.go
@@ -659,7 +659,11 @@ func (store *Store) NewSigner(key common.RawBytes, meta infra.SignerMeta) (infra
 }
 
 func (store *Store) NewVerifier() infra.Verifier {
-	return NewBasicVerifier(store)
+	verifiabilityRange := infra.SignatureTimestampRange{
+		MaxPldAge:   10 * time.Second,
+		MaxInFuture: 10 * time.Second,
+	}
+	return NewBasicVerifier(store).WithSignatureTimestampRange(verifiabilityRange)
 }
 
 // ByAttributes returns a list of ASes in the specified ISD that


### PR DESCRIPTION
In SCIONLab the clocks are not well synchornized. We allow up to 10 seconds difference
among clocks in different machines.
This particular patch relies on  instead of modifying the
default values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/netsec-scion/58)
<!-- Reviewable:end -->
