### PR TITLE
Improve Segment verification

### DIFF
--- a/go/lib/infra/modules/segverifier/segverifier.go
+++ b/go/lib/infra/modules/segverifier/segverifier.go
@@ -207,11 +207,9 @@ func verifySegment(ctx context.Context, verifier infra.Verifier, server net.Addr
 func VerifySegment(ctx context.Context, verifier infra.Verifier, server net.Addr,
 	segment *seg.PathSegment) error {
 
-	log.Debug("[juagargi] VerifySegment", "segment", segment)
 	for i, asEntry := range segment.ASEntries {
 		// Bind the verifier to the values specified in the AS Entry since
 		// the sign meta does not carry this information.
-		log.Debug("[juagargi] VerifySegment, inside loop", "asEntry", asEntry)
 		verifier := verifier.WithServer(server).WithSrc(ctrl.SignSrcDef{
 			IA:       asEntry.IA(),
 			ChainVer: asEntry.CertVer,

--- a/go/lib/infra/modules/segverifier/segverifier.go
+++ b/go/lib/infra/modules/segverifier/segverifier.go
@@ -207,12 +207,15 @@ func verifySegment(ctx context.Context, verifier infra.Verifier, server net.Addr
 func VerifySegment(ctx context.Context, verifier infra.Verifier, server net.Addr,
 	segment *seg.PathSegment) error {
 
+	log.Debug("[juagargi] VerifySegment", "segment", segment)
 	for i, asEntry := range segment.ASEntries {
 		// Bind the verifier to the values specified in the AS Entry since
 		// the sign meta does not carry this information.
+		log.Debug("[juagargi] VerifySegment, inside loop", "asEntry", asEntry)
 		verifier := verifier.WithServer(server).WithSrc(ctrl.SignSrcDef{
 			IA:       asEntry.IA(),
 			ChainVer: asEntry.CertVer,
+			TRCVer:   asEntry.TrcVer,
 		})
 		if err := segment.VerifyASEntry(ctx, verifier, i); err != nil {
 			return common.NewBasicError("segverifier.VerifySegment", err, "segment", segment,

--- a/go/lib/infra/modules/trust/signhelper.go
+++ b/go/lib/infra/modules/trust/signhelper.go
@@ -226,6 +226,12 @@ func (v *BasicVerifier) verify(ctx context.Context, msg common.RawBytes,
 	if err := v.checkSrc(src); err != nil {
 		return err
 	}
+	topts := infra.TRCOpts{
+		TrustStoreOpts: infra.TrustStoreOpts{Server: v.server},
+	}
+	if _, err := v.store.GetTRC(ctx, src.IA.I, scrypto.Version(src.TRCVer), topts); err != nil {
+		return err
+	}
 	opts := infra.ChainOpts{
 		TrustStoreOpts: infra.TrustStoreOpts{Server: v.server},
 	}

--- a/go/lib/infra/modules/trust/signhelper.go
+++ b/go/lib/infra/modules/trust/signhelper.go
@@ -25,7 +25,6 @@ import (
 	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
 	"github.com/scionproto/scion/go/lib/infra"
-	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/scrypto"
 	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/proto"

--- a/go/lib/infra/modules/trust/signhelper.go
+++ b/go/lib/infra/modules/trust/signhelper.go
@@ -25,6 +25,7 @@ import (
 	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
 	"github.com/scionproto/scion/go/lib/infra"
+	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/scrypto"
 	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/proto"
@@ -226,12 +227,20 @@ func (v *BasicVerifier) verify(ctx context.Context, msg common.RawBytes,
 	if err := v.checkSrc(src); err != nil {
 		return err
 	}
+	logger := log.FromCtx(ctx)
+	logger.Debug("[kmateusz] YO MAN 1")
 	topts := infra.TRCOpts{
 		TrustStoreOpts: infra.TrustStoreOpts{Server: v.server},
 	}
-	if _, err := v.store.GetTRC(ctx, src.IA.I, scrypto.Version(src.TRCVer), topts); err != nil {
+	logger.Debug("[kmateusz] YO MAN 2")
+	logger.Debug("[kmateusz] ", "src", src)
+	_, err = v.store.GetTRC(ctx, src.IA.I, scrypto.Version(src.TRCVer), topts)
+
+	if err != nil {
+		logger.Debug("[kmateusz] YO MAN ERROR 1")
 		return err
 	}
+	logger.Debug("[kmateusz] YO MAN 3")
 	opts := infra.ChainOpts{
 		TrustStoreOpts: infra.TrustStoreOpts{Server: v.server},
 	}

--- a/go/lib/infra/modules/trust/signhelper.go
+++ b/go/lib/infra/modules/trust/signhelper.go
@@ -227,11 +227,9 @@ func (v *BasicVerifier) verify(ctx context.Context, msg common.RawBytes,
 	if err := v.checkSrc(src); err != nil {
 		return err
 	}
-	logger := log.FromCtx(ctx)
 	topts := infra.TRCOpts{
 		TrustStoreOpts: infra.TrustStoreOpts{Server: v.server},
 	}
-	logger.Debug("[TrustStore:BasicVerifier] Verifying", "src", src)
 	if _, err = v.store.GetTRC(ctx, src.IA.I, scrypto.Version(src.TRCVer), topts); err != nil {
 		return err
 	}

--- a/go/lib/infra/modules/trust/signhelper.go
+++ b/go/lib/infra/modules/trust/signhelper.go
@@ -228,19 +228,13 @@ func (v *BasicVerifier) verify(ctx context.Context, msg common.RawBytes,
 		return err
 	}
 	logger := log.FromCtx(ctx)
-	logger.Debug("[kmateusz] YO MAN 1")
 	topts := infra.TRCOpts{
 		TrustStoreOpts: infra.TrustStoreOpts{Server: v.server},
 	}
-	logger.Debug("[kmateusz] YO MAN 2")
-	logger.Debug("[kmateusz] ", "src", src)
-	_, err = v.store.GetTRC(ctx, src.IA.I, scrypto.Version(src.TRCVer), topts)
-
-	if err != nil {
-		logger.Debug("[kmateusz] YO MAN ERROR 1")
+	logger.Debug("[TrustStore:BasicVerifier] Verifying", "src", src)
+	if _, err = v.store.GetTRC(ctx, src.IA.I, scrypto.Version(src.TRCVer), topts); err != nil {
 		return err
 	}
-	logger.Debug("[kmateusz] YO MAN 3")
 	opts := infra.ChainOpts{
 		TrustStoreOpts: infra.TrustStoreOpts{Server: v.server},
 	}


### PR DESCRIPTION
It has been discovered TRCs are verified only against local trust store even if the packet is signed with a TRC which is newer than one available in the store.

This provides a workaround for this issue also fixing an underlying bug where TRCVer is ommited during segment verification.

Closes-Bug: ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/netsec-scion/60)
<!-- Reviewable:end -->
