### PR TITLE
The UT needs a TRC in the trust DB

### DIFF
--- a/go/lib/infra/modules/trust/signhelper_test.go
+++ b/go/lib/infra/modules/trust/signhelper_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/scrypto"
 	"github.com/scionproto/scion/go/lib/scrypto/cert"
+	"github.com/scionproto/scion/go/lib/scrypto/trc"
 	"github.com/scionproto/scion/go/lib/xtest"
 	"github.com/scionproto/scion/go/proto"
 )
@@ -73,6 +74,10 @@ func TestBasicVerifierVerify(t *testing.T) {
 					Version:   1,
 					Signature: []byte("signature"),
 				},
+			})
+			store.trustdb.InsertTRC(context.Background(), &trc.TRC{
+				ISD:     ia110.I,
+				Version: 1,
 			})
 			require.NoError(t, err)
 			verifier := NewBasicVerifier(store)


### PR DESCRIPTION
Git bisect showed that we broke a UT in `2b09bca57313b27e6cb1b443e8b0040fb2c8be39` .
This fix adds a valid TRC in the trust DB so that the validation won't fail because a TRC not found.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/netsec-scion/62)
<!-- Reviewable:end -->
