### PR TITLE
Revert "Add non-docker option for zookeeper back"

### DIFF
--- a/env/debian/pkgs.txt
+++ b/env/debian/pkgs.txt
@@ -49,4 +49,3 @@ sudo
 tzdata
 uthash-dev
 vim-common
-zookeeperd

--- a/scion.sh
+++ b/scion.sh
@@ -93,12 +93,7 @@ run_zk() {
         return
     fi
     echo "Running zookeeper..."
-    if is_docker_zk; then
-        host_zk_stop || true
-        ./tools/quiet ./tools/dc zk up -d
-    else
-        host_zk_start
-    fi
+    ./tools/quiet ./tools/dc zk up -d
     if [ -n "$1" ]; then
         echo "Deleting all Zookeeper state"
         # Wait some time, such that zookeeper accepts connections again after startup
@@ -106,7 +101,7 @@ run_zk() {
         local addr="127.0.0.1:2181"
         if is_running_in_docker; then
             addr="${DOCKER0:-172.17.0.1}:2182"
-        elif is_docker_zk; then
+        elif is_docker_be; then
             addr="$(./tools/docker-ip):2181"
         fi
         tools/zkcleanslate --zk "$addr"
@@ -127,14 +122,6 @@ stop_jaeger() {
     fi
     echo "Stopping jaeger..."
     ./tools/quiet ./tools/dc jaeger down
-}
-
-host_zk_start() {
-    systemctl is-active --quiet zookeeper || sudo -p "Starting local zk - [sudo] password for %p: " systemctl start zookeeper
-}
-
-host_zk_stop() {
-    systemctl is-active --quiet zookeeper && sudo -p "Stopping local zk - [sudo] password for %p: " systemctl stop zookeeper
 }
 
 cmd_mstart() {
@@ -256,10 +243,6 @@ glob_match() {
 
 is_docker_be() {
     [ -f gen/scion-dc.yml ]
-}
-
-is_docker_zk() {
-    is_docker_be || [ -f gen/zk-dc.yml ]
 }
 
 is_supervisor() {


### PR DESCRIPTION
Not needed anymore. We don't typically need zookeeper anyway so no need for this special setup anymore.
In particular, this removes zookeeper from dependencies.

This reverts #19
This reverts commit b1711994926b8b5ceab8d4df9f9b4be5084d27e5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/netsec-scion/66)
<!-- Reviewable:end -->
